### PR TITLE
FIX: Cursor and Statusline Jitters on Start-Up, Saving, Scroll etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Highly experimental plugin that completely replaces the UI for `messages`, `cmdl
 - 📝 command output like [:messages](https://neovim.io/doc/user/message.html#:messages)
   is shown in normal buffers, which makes it much easier to work with
 - 📚 `:Noice` command to show a full message history
-- ⌨️  no more [:h more-prompt](https://neovim.io/doc/user/message.html#more-prompt)
+- ⌨️ no more [:h more-prompt](https://neovim.io/doc/user/message.html#more-prompt)
 - 💻 fully customizable **cmdline** with icons
 - 💅 **syntax highlighting** for `vim` and `lua` on the **cmdline**
 - 🚥 **statusline** components
@@ -23,7 +23,7 @@ Highly experimental plugin that completely replaces the UI for `messages`, `cmdl
 
 - Neovim >= 0.8.0
 - [nui.nvim](https://github.com/MunifTanjim/nui.nvim): used for proper rendering and multiple views
-- [nvim-notify](https://github.com/rcarriga/nvim-notify):  notification view ___(optional)___
+- [nvim-notify](https://github.com/rcarriga/nvim-notify): notification view **_(optional)_**
 
 ## 📦 Installation
 
@@ -77,6 +77,9 @@ Check the [wiki](https://github.com/folke/noice.nvim/wiki/Configuration-Recipes)
     view_history = "split", -- view for :messages
     view_search = "virtualtext", -- view for search count messages. Set to `false` to disable
   },
+	check_health = {
+		enable = true, -- enables health check on start up
+	},
   popupmenu = {
     enabled = true, -- enables the Noice popupmenu UI
     ---@type 'nui'|'cmp'
@@ -126,7 +129,7 @@ Check the [wiki](https://github.com/folke/noice.nvim/wiki/Configuration-Recipes)
 **Noice** uses filters to route messages to specific views.
 
 | Name           | Type                   | Description                                                                                                                            |
-|  ------------- |  --------------------- |  ------------------------------------------------------------------------------------------------------------------------------------- |
+| -------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | **cleared**    | `boolean`              | checks if the message is cleared, meaning it's in the history                                                                          |
 | **mode**       | `string`               | checks if `vim.api.nvim_get_mode()` contains the given mode                                                                            |
 | **blocking**   | `boolean`              | are we in blocking mode?                                                                                                               |
@@ -172,16 +175,16 @@ local filter = {
 A **View** (`config.views`) is a combination of a `backend` and options.
 **Noice** comes with the following built-in views with sane defaults:
 
-| View              | Backend    | Description                                                                                                                |
-|  ---------------- |  --------- |  ------------------------------------------------------------------------------------------------------------------------- |
-| **notify**        | `notify`   | _nvim-notify_ with `level=true`, `replace=true`, `merge=true`                                                              |
-| **split**         | `split`    | horizontal split                                                                                                           |
-| **vsplit**        | `split`    | vertical split                                                                                                             |
-| **popup**         | `popup`    | simple popup                                                                                                               |
-| **mini**          | `mini`     | minimal view, by default bottom right, right-aligned                                                                       |
-| **cmdline**       | `popup`    | bottom line, similar to the classic cmdline                                                                                |
-| **cmdline_popup** | `popup`    | fancy cmdline popup, with different styles according to the cmdline mode                                                   |
-| **popupmenu**     | `nui.menu` | special view with the options used to render the popupmenu when backend is **nui**                                         |
+| View              | Backend    | Description                                                                        |
+| ----------------- | ---------- | ---------------------------------------------------------------------------------- |
+| **notify**        | `notify`   | _nvim-notify_ with `level=true`, `replace=true`, `merge=true`                      |
+| **split**         | `split`    | horizontal split                                                                   |
+| **vsplit**        | `split`    | vertical split                                                                     |
+| **popup**         | `popup`    | simple popup                                                                       |
+| **mini**          | `mini`     | minimal view, by default bottom right, right-aligned                               |
+| **cmdline**       | `popup`    | bottom line, similar to the classic cmdline                                        |
+| **cmdline_popup** | `popup`    | fancy cmdline popup, with different styles according to the cmdline mode           |
+| **popupmenu**     | `nui.menu` | special view with the options used to render the popupmenu when backend is **nui** |
 
 Please refer to [noice.config.views](https://github.com/folke/noice.nvim/blob/main/lua/noice/config/views.lua)
 to see the options.
@@ -238,7 +241,7 @@ String or can also be a table like:
 ### Notify Options
 
 | Option      | Type             | Default  | Description                                                                                                                             |
-|  ---------- |  --------------- |  ------- |  -------------------------------------------------------------------------------------------------------------------------------------- |
+| ----------- | ---------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | **title**   | `string`         | `nil`    | title to be used for the notification. Uses `Message.title` if available.                                                               |
 | **replace** | `boolean`        | `true`   | when true, messages routing to the same notify instance will replace existing messages instead of pushing a new notification every time |
 | **merge**   | `boolean`        | `true`   | Merge messages into one Notification or create separate notifications                                                                   |
@@ -304,7 +307,7 @@ A **route** has a `filter`, `view` and optional `opts` attribute.
 Route options can be any of the view options above, or one of:
 
 | Option   | Type      | Default | Description                                                                                                                                                          |
-|  ------- |  -------- |  ------ |  ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| -------- | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **skip** | `boolean` | `false` | messages matching this filter will be skipped and not shown in any views                                                                                             |
 | **stop** | `boolean` | `true`  | When `false` and a route matches the filter, then other routes can still process the message too. Useful if you want certain messages to be shown in multiple views. |
 
@@ -405,7 +408,7 @@ require("telescope").load_extension("noice")
 
 ## 🚀 Usage
 
-- `:Noice` shows the message history  
+- `:Noice` shows the message history
 - `:Noice disable` disables **Noice**
 - `:Noice enable` enables **Noice**
 - `:Noice stats` shows debugging stats
@@ -414,8 +417,9 @@ require("telescope").load_extension("noice")
 ## 🌈 Highlight Groups
 
 <!-- hl_start -->
+
 | Highlight Group                   | Default Group                | Description                                        |
-|  -------------------------------- |  --------------------------- |  ------------------------------------------------- |
+| --------------------------------- | ---------------------------- | -------------------------------------------------- |
 | **NoiceCmdline**                  | _MsgArea_                    | Normal for the classic cmdline area at the bottom" |
 | **NoiceCmdlineIcon**              | _DiagnosticSignInfo_         | Cmdline icon                                       |
 | **NoiceCmdlineIconSearch**        | _DiagnosticSignWarn_         | Cmdline search icon (`/` and `?`)                  |
@@ -454,6 +458,7 @@ require("telescope").load_extension("noice")
 | **NoiceSplit**                    | _NormalFloat_                | Normal for split views                             |
 | **NoiceSplitBorder**              | _FloatBorder_                | Border for split views                             |
 | **NoiceVirtualText**              | _DiagnosticVirtualTextInfo_  | Default hl group for virtualtext views             |
+
 <!-- hl_end -->
 
 ## 🔥 Known Issues

--- a/lua/noice/config/init.lua
+++ b/lua/noice/config/init.lua
@@ -34,6 +34,9 @@ M.defaults = {
     ---@type 'nui'|'cmp'
     backend = "nui", -- backend to use to show regular cmdline completions
   },
+  check_health = {
+    enable = true, -- Health Check
+  },
   ---@type NoiceRouteConfig
   history = {
     -- options for the message history that you get with `:Noice`

--- a/lua/noice/init.lua
+++ b/lua/noice/init.lua
@@ -10,8 +10,10 @@ M.api = Api
 
 ---@param opts? NoiceConfig
 function M.setup(opts)
-  if not Health.check({ checkhealth = false, loaded = false }) then
-    return
+  if opts and opts.check_health.enable == true then
+    if not Health.check({ checkhealth = false, loaded = false }) then
+      return
+    end
   end
 
   require("noice.util").try(function()


### PR DESCRIPTION
Temporary Fix: Skip Health Check to Prevent The Jitters on Save, Start-Up, Linting, Formatting  etc