### PR TITLE
fix: use a typical search icon by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Check the [wiki](https://github.com/folke/noice.nvim/wiki/Configuration-Recipes)
       -- opts: any options passed to the view
       -- icon_hl_group: optional hl_group for the icon
       cmdline = { pattern = "^:", icon = "", lang = "vim" },
-      search_down = { kind = "search", pattern = "^/", icon = " ", lang = "regex" },
-      search_up = { kind = "search", pattern = "^%?", icon = " ", lang = "regex" },
+      search_down = { kind = "search", pattern = "^/", icon = " ", lang = "regex" },
+      search_up = { kind = "search", pattern = "^%?", icon = " ", lang = "regex" },
       filter = { pattern = "^:%s*!", icon = "$", lang = "bash" },
       lua = { pattern = "^:%s*lua%s+", icon = "", lang = "lua" },
       help = { pattern = "^:%s*h%s+", icon = "" },

--- a/lua/noice/config/init.lua
+++ b/lua/noice/config/init.lua
@@ -19,8 +19,8 @@ M.defaults = {
       -- opts: any options passed to the view
       -- icon_hl_group: optional hl_group for the icon
       cmdline = { pattern = "^:", icon = "", lang = "vim" },
-      search_down = { kind = "search", pattern = "^/", icon = " ", lang = "regex" },
-      search_up = { kind = "search", pattern = "^%?", icon = " ", lang = "regex" },
+      search_down = { kind = "search", pattern = "^/", icon = " ", lang = "regex" },
+      search_up = { kind = "search", pattern = "^%?", icon = " ", lang = "regex" },
       filter = { pattern = "^:%s*!", icon = "$", lang = "bash" },
       lua = { pattern = "^:%s*lua%s+", icon = "", lang = "lua" },
       help = { pattern = "^:%s*h%s+", icon = "" },


### PR DESCRIPTION
The icon provided as default was slightly confusing at first. I was not sure if the icon was missing or not. So I found a default icon that makes more sense to new users.

I propose this icon as default
<img width="77" alt="Screen Shot 2022-10-25 at 10 54 37 am" src="https://user-images.githubusercontent.com/7098556/197651662-f71c6cf7-590d-4bad-9478-5389d18e6505.png">

As opposed to this, which looks too close to a help prompt icon
<img width="78" alt="Screen Shot 2022-10-25 at 10 54 50 am" src="https://user-images.githubusercontent.com/7098556/197651635-bbbb05d5-e288-4fbf-8808-a0fb9be4458a.png">
