### PR TITLE
fix(smart_move): Dont move `cmdline` view

### DIFF
--- a/lua/noice/view/nui.lua
+++ b/lua/noice/view/nui.lua
@@ -45,7 +45,10 @@ end
 
 -- Check if other floating windows are overlapping and move out of the way
 function NuiView:smart_move()
-  if not (self._opts.type == "popup" and self._opts.relative and self._opts.relative.type == "editor") then
+  if
+    not (self._opts.type == "popup" and self._opts.relative and self._opts.relative.type == "editor")
+    or self._opts.view == "cmdline"
+  then
     return
   end
 


### PR DESCRIPTION
\#117 Added the smart_move function that avoids overlap. But it introduced some bugs with cmdline view set to `cmdline`. To avoid overlap with `mini` or other views, the cmdline itself would move to odd locations. This fixes that issue.