### PR TITLE
feat(conceal): Toggle conceal on hover focus

### DIFF
--- a/lua/noice/source/lsp/init.lua
+++ b/lua/noice/source/lsp/init.lua
@@ -56,6 +56,7 @@ function M.try_enter(message)
       local win = vim.fn.bufwinid(buf)
       if win ~= -1 then
         vim.api.nvim_set_current_win(win)
+        vim.wo[win].conceallevel = 0
         return true
       end
     end


### PR DESCRIPTION
Possible opinionated PR. When focusing/entering the hover window, set conceallevel to 0 to view links and other info.

Example use case: in lua-language-server, for stdlib items, the hover window has links to the reference manual. When concealed, not very easy to execute `gx` or other `go-to` commands