### PR TITLE
fix(telescope): Correct index for finder

### DIFF
--- a/lua/telescope/_extensions/noice.lua
+++ b/lua/telescope/_extensions/noice.lua
@@ -27,7 +27,7 @@ function M.display(message)
 end
 
 function M.finder()
-  local messages = Manager.get(Config.options.history.filter, {
+  local messages = Manager.get(Config.options.commands.history.filter, {
     history = true,
     sort = true,
     reverse = true,


### PR DESCRIPTION
Use `Config.options.commands.history` instead of `Config.options.history`

Its a new regression that caused errors when using `Noice telescope`