### PR TITLE
fix: double check triggerCharacters is not nil

### DIFF
--- a/lua/noice/lsp/signature.lua
+++ b/lua/noice/lsp/signature.lua
@@ -59,7 +59,7 @@ function M.setup(group)
       local client = vim.lsp.get_client_by_id(args.data.client_id)
       if client.server_capabilities.signatureHelpProvider then
         local chars = client.server_capabilities.signatureHelpProvider.triggerCharacters
-        if #chars > 0 then
+        if chars ~= nill and #chars > 0 then
           local callback = M.check(buf, chars, client.offset_encoding)
           if Config.options.lsp.signature.auto_open.luasnip then
             vim.api.nvim_create_autocmd("User", {


### PR DESCRIPTION
# Description

This PR improve validation in case the variable holds a `nil` value on it.

```
14:29:15 msg_show Error executing lua callback: ...pack/packer/start/noice.nvim/lua/noice/lsp/signature.lua:62: attempt to get length of local 'chars' (a nil value)
stack traceback:
	...pack/packer/start/noice.nvim/lua/noice/lsp/signature.lua:62: in function <...pack/packer/start/noice.nvim/lua/noice/lsp/signature.lua:57>
	[C]: in function 'nvim_exec_autocmds'
	...r/neovim/HEAD-3de2a7f/share/nvim/runtime/lua/vim/lsp.lua:1522: in function '_on_attach'
	...r/neovim/HEAD-3de2a7f/share/nvim/runtime/lua/vim/lsp.lua:1354: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```