### PR TITLE
fix: cmp popupmenu position

### DIFF
--- a/lua/noice/util/hacks.lua
+++ b/lua/noice/util/hacks.lua
@@ -3,6 +3,7 @@ local require = require("noice.util.lazy")
 local Util = require("noice.util")
 local Router = require("noice.message.router")
 local Api = require("noice.api")
+local Cmdline = require("noice.ui.cmdline")
 
 -- HACK: a bunch of hacks to make Noice behave
 local M = {}
@@ -241,7 +242,8 @@ function M.fix_cmp()
     if api.is_cmdline_mode() then
       local pos = Api.get_cmdline_position()
       if pos then
-        return { pos.screenpos.row, pos.screenpos.col + vim.fn.getcmdpos() - 1 }
+        local col = vim.fn.getcmdpos() - Cmdline.last().offset
+        return { pos.screenpos.row, pos.screenpos.col +  col }
       end
     end
     return get_screen_cursor()


### PR DESCRIPTION
Currently, the popupmenu position of `cmp` is not aligned with input of smart-cmdline, because of its offset. Adjust the screen cursor position with offset should fix it. I try to access the offset directly by `Cmdline.last().offset`, but I'm not sure it's the right way.

**Before**

<img width="558" alt="截屏2022-10-31 13 34 38" src="https://user-images.githubusercontent.com/40141251/198940090-dfb8f99b-5115-420b-a2ea-c8d260c009bb.png">

**After**

<img width="548" alt="截屏2022-10-31 13 35 05" src="https://user-images.githubusercontent.com/40141251/198940109-58f6e946-064b-46d6-932d-9ae713f92ad9.png">
