### PR TITLE
feat: manage message state without msg_clear

### DIFF
--- a/lua/noice/commands.lua
+++ b/lua/noice/commands.lua
@@ -18,14 +18,14 @@ M.commands = {}
 function M.command(command)
   return function()
     local view = View.get_view(command.view, command.opts)
-    view:display(Manager.get(
+    view:set(Manager.get(
       command.filter,
       vim.tbl_deep_extend("force", {
         history = true,
         sort = true,
       }, command.filter_opts or {})
     ))
-    view:show()
+    view:display()
   end
 end
 
@@ -84,11 +84,11 @@ function M.setup()
   end, {
     nargs = "?",
     desc = "Noice",
-    complete = function(f, line, ...)
+    complete = function(_, line)
       if line:match("^%s*Noice %w+ ") then
         return {}
       end
-      local prefix = line:match("^%s*Noice (%w*)")
+      local prefix = line:match("^%s*Noice (%w*)") or ""
       return vim.tbl_filter(function(key)
         return key:find(prefix) == 1
       end, vim.tbl_keys(M.commands))

--- a/lua/noice/commands.lua
+++ b/lua/noice/commands.lua
@@ -67,6 +67,11 @@ function M.setup()
       message:set(vim.inspect(Config.options))
       Manager.add(message)
     end,
+    viewstats = function()
+      local message = Message("noice", "debug")
+      message:set(vim.inspect(require("noice.message.router").view_stats()))
+      Manager.add(message)
+    end,
   }
 
   for name, command in pairs(Config.options.commands) do

--- a/lua/noice/lsp/message.lua
+++ b/lua/noice/lsp/message.lua
@@ -33,7 +33,6 @@ function M.on_message(_, result, ctx)
       message.level = level
     end
   end
-  message.once = true
   Manager.add(message)
 end
 

--- a/lua/noice/lsp/progress.lua
+++ b/lua/noice/lsp/progress.lua
@@ -46,7 +46,6 @@ function M.progress(_, msg, info)
       ---@type string
       client = client and client.name or ("lsp-" .. info.client_id),
     }
-    -- message.once = true
     M._progress[id] = message
   end
 

--- a/lua/noice/message/filter.lua
+++ b/lua/noice/message/filter.lua
@@ -10,7 +10,7 @@ local M = {}
 ---@class NoiceFilter
 ---@field event? NoiceEvent|NoiceEvent[]
 ---@field kind? NoiceKind|NoiceKind[]
----@field message? NoiceMessage
+---@field message? NoiceMessage|NoiceMessage[]
 ---@field any? NoiceFilter[]
 ---@field not? NoiceFilter
 ---@field min_height? integer
@@ -55,7 +55,14 @@ M.filters = {
   end,
   message = function(message, other)
     ---@cast message NoiceMessage
-    return other.id == message.id
+    other = vim.tbl_islist(other) and other or { other }
+    ---@cast other NoiceMessage[]
+    for _, m in ipairs(other) do
+      if m.id == message.id then
+        return true
+      end
+    end
+    return false
   end,
   error = function(message, error)
     ---@cast message NoiceMessage

--- a/lua/noice/message/filter.lua
+++ b/lua/noice/message/filter.lua
@@ -21,6 +21,7 @@ local M = {}
 ---@field max_length? integer
 ---@field find? string
 ---@field error? boolean
+---@field has? boolean
 ---@field warning? boolean
 ---@field mode? string
 ---@field blocking? boolean
@@ -31,6 +32,10 @@ M.filters = {
   cleared = function(message, cleared)
     ---@cast message NoiceMessage
     return cleared == not Manager.has(message)
+  end,
+  has = function(message, has)
+    ---@cast message NoiceMessage
+    return has == Manager.has(message, { history = true })
   end,
   mode = function(_, mode)
     return vim.api.nvim_get_mode().mode:find(mode)

--- a/lua/noice/message/init.lua
+++ b/lua/noice/message/init.lua
@@ -11,7 +11,6 @@ local _id = 0
 ---@field event NoiceEvent
 ---@field ctime number
 ---@field mtime number
----@field once? boolean
 ---@field tick number
 ---@field level? NotifyLevel
 ---@field kind? NoiceKind

--- a/lua/noice/message/manager.lua
+++ b/lua/noice/message/manager.lua
@@ -31,7 +31,7 @@ end
 ---@param opts? { history: boolean } # defaults to `{ history = false }`
 function M.has(message, opts)
   opts = opts or {}
-  return (opts.history and M._history or M._messages)[message.id]
+  return (opts.history and M._history or M._messages)[message.id] ~= nil
 end
 
 ---@param message NoiceMessage

--- a/lua/noice/message/router.lua
+++ b/lua/noice/message/router.lua
@@ -71,6 +71,29 @@ function M.check_redraw()
   end
 end
 
+function M.view_stats()
+  ---@type table<NoiceView, boolean>
+  local views = {}
+  for _, route in ipairs(M._routes) do
+    if route.view then
+      views[route.view] = true
+    end
+  end
+
+  local ret = {}
+
+  -- remove deleted messages and new messages from the views
+  for view, _ in pairs(views) do
+    if #view._messages > 0 then
+      if not ret[view._opts.view] then
+        ret[view._opts.view] = 0
+      end
+      ret[view._opts.view] = ret[view._opts.view] + #view._messages
+    end
+  end
+  return ret
+end
+
 function M.update()
   -- only update on changes
   if M._tick == Manager.tick() then

--- a/lua/noice/source/notify.lua
+++ b/lua/noice/source/notify.lua
@@ -4,7 +4,6 @@ local Message = require("noice.message")
 local Manager = require("noice.message.manager")
 local Router = require("noice.message.router")
 local Util = require("noice.util")
-local Msg = require("noice.ui.msg")
 
 local M = {}
 
@@ -60,7 +59,6 @@ function M.notify(msg, level, opts)
     message.opts.is_nil = true
   end
 
-  Msg.check_clear()
   Manager.add(message)
   if Util.is_blocking() then
     Router.update()

--- a/lua/noice/source/notify.lua
+++ b/lua/noice/source/notify.lua
@@ -54,7 +54,6 @@ function M.notify(msg, level, opts)
   local message = Message("notify", level, msg)
   message.opts = opts or {}
   message.level = level
-  message.once = true
 
   if msg == nil then
     -- special case for some destinations like nvim-notify

--- a/lua/noice/text/format/init.lua
+++ b/lua/noice/text/format/init.lua
@@ -117,16 +117,36 @@ end
 
 ---@alias NoiceAlign "center" | "left" | "right" | "message-center" | "message-left" | "message-right" | "line-center" | "line-left" | "line-right"
 
+---@param messages NoiceMessage[]
+---@param align? NoiceAlign
+function M.align(messages, align)
+  local width = 0
+  for _, m in ipairs(messages) do
+    for _, line in ipairs(m._lines) do
+      ---@diagnostic disable-next-line: undefined-field
+      if line._texts[1] and line._texts[1].padding then
+        table.remove(line._texts, 1)
+      end
+    end
+    width = math.max(width, m:width())
+  end
+
+  for _, m in ipairs(messages) do
+    M._align(m, width, align)
+  end
+end
+
 ---@param message NoiceMessage
 ---@param width integer
 ---@param align? NoiceAlign
-function M.align(message, width, align)
+function M._align(message, width, align)
   if align == nil or align == "left" then
     return
   end
 
   local align_object = "message"
 
+  ---@type string, string
   local ao, a = align:match("^(.-)%-(.-)$")
   if a then
     align = a
@@ -138,8 +158,12 @@ function M.align(message, width, align)
     if w < width then
       if align == "right" then
         table.insert(line._texts, 1, NuiText(string.rep(" ", width - w)))
+        ---@diagnostic disable-next-line: no-unknown
+        line._texts[1].padding = true
       elseif align == "center" then
         table.insert(line._texts, 1, NuiText(string.rep(" ", math.floor((width - w) / 2 + 0.5))))
+        ---@diagnostic disable-next-line: no-unknown
+        line._texts[1].padding = true
       end
     end
   end

--- a/lua/noice/util/hacks.lua
+++ b/lua/noice/util/hacks.lua
@@ -18,7 +18,6 @@ function M.enable()
   M.reset_augroup()
   M.fix_incsearch()
   M.fix_input()
-  M.fix_nohlsearch()
   M.fix_redraw()
   M.fix_cmp()
   M.fix_vim_sleuth()
@@ -41,7 +40,8 @@ end
 function M.fix_nohlsearch()
   M.fix_nohlsearch = Util.interval(30, function()
     if vim.v.hlsearch == 0 then
-      require("noice.message.manager").clear({ kind = "search_count" })
+      local m = require("noice.ui.msg").get("msg_show", "search_count")
+      require("noice.message.manager").remove(m)
     end
   end, {
     enabled = function()

--- a/lua/noice/view/backend/mini.lua
+++ b/lua/noice/view/backend/mini.lua
@@ -68,6 +68,7 @@ function MiniView:show()
     self.active[message.id] = message
     self:autohide(message.id)
   end
+  self:clear()
   self:update()
 end
 
@@ -85,7 +86,8 @@ function MiniView:update()
       return ret
     end
   )
-  self.view:display(active, { dirty = true })
+  self.view:set(active)
+  self.view:display()
 end
 
 function MiniView:hide() end

--- a/lua/noice/view/backend/notify.lua
+++ b/lua/noice/view/backend/notify.lua
@@ -178,6 +178,7 @@ function NotifyView:show()
       })
     end
   end
+  self:clear()
 
   for _, msg in ipairs(todo) do
     self:_notify(msg)

--- a/lua/noice/view/backend/notify_send.lua
+++ b/lua/noice/view/backend/notify_send.lua
@@ -143,6 +143,7 @@ function NotifySendView:show()
       })
     end
   end
+  self:clear()
 
   for _, msg in ipairs(todo) do
     self:_notify(msg)

--- a/lua/noice/view/init.lua
+++ b/lua/noice/view/init.lua
@@ -89,9 +89,25 @@ end
 
 function View:update_options() end
 
----@param message NoiceMessage
-function View:push(message)
-  -- FIXME:
+---@param messages NoiceMessage|NoiceMessage[]
+---@param opts? {format?: boolean}
+function View:push(messages, opts)
+  opts = opts or {}
+
+  messages = vim.tbl_islist(messages) and messages or { messages }
+  ---@cast messages NoiceMessage[]
+
+  for _, message in ipairs(messages) do
+    if opts.format ~= false then
+      message = Format.format(message, self._opts.format)
+    end
+    table.insert(self._messages, message)
+  end
+end
+
+function View:clear()
+  self._messages = {}
+  self._route_opts = {}
 end
 
 function View:check_options()
@@ -105,52 +121,26 @@ function View:check_options()
 end
 
 ---@param messages NoiceMessage[]
----@param opts? {dirty?:boolean, format?: boolean}
-function View:display(messages, opts)
+---@param opts? {format?: boolean}
+function View:set(messages, opts)
   opts = opts or {}
-  local dirty = (#messages ~= #self._messages) or opts.dirty
-  for _, m in ipairs(messages) do
-    if m.tick > self._tick then
-      self._tick = m.tick
-      dirty = true
-    end
-  end
-
-  if dirty then
-    if opts.format == false then
-      self._messages = messages
-    else
-      self:format(messages)
-    end
-    if #self._messages > 0 then
-      self:check_options()
-
-      Util.try(self.show, self)
-
-      self._visible = true
-    else
-      self._visible = false
-      self:hide()
-    end
-    return true
-  end
-  return false
+  self:clear()
+  self:push(messages, opts)
 end
 
----@param messages NoiceMessage[]
-function View:format(messages)
-  self._messages = vim.tbl_map(
-    ---@param message NoiceMessage
-    function(message)
-      return require("noice.text.format").format(message, self._opts.format)
-    end,
-    messages
-  )
+function View:display()
+  if #self._messages > 0 then
+    Format.align(self._messages, self._opts.align)
+    self:check_options()
 
-  local width = self:width()
-  for _, message in ipairs(self._messages) do
-    Format.align(message, width, self._opts.align)
+    Util.try(self.show, self)
+
+    self._visible = true
+  else
+    self._visible = false
+    self:hide()
   end
+  return true
 end
 
 ---@param old NoiceViewOptions

--- a/lua/noice/view/init.lua
+++ b/lua/noice/view/init.lua
@@ -89,6 +89,11 @@ end
 
 function View:update_options() end
 
+---@param message NoiceMessage
+function View:push(message)
+  -- FIXME:
+end
+
 function View:check_options()
   ---@type NoiceViewOptions
   local old = vim.deepcopy(self._opts)

--- a/lua/noice/view/nui.lua
+++ b/lua/noice/view/nui.lua
@@ -185,6 +185,7 @@ function NuiView:hide()
 
     Util.protect(function()
       if self._nui and not self._visible then
+        self:clear()
         self._nui:hide()
         self._scroll:hide()
       end


### PR DESCRIPTION
Message state is currently managed Neovim `msg_clear` events, which lead to all sorts of problems, since Noice is more than just Neovim messages.

The new implementation no longer uses `msg_clear` events.

Incoming messages are now routed directly to the correct views. Views manage message state:
- notify/mini: clear messages once the message has been dispatched into the view
- nui views: clear messages on close of the view
