### PR TITLE
fix: lsp completion docs missing property detail

### DIFF
--- a/lua/noice/lsp/override.lua
+++ b/lua/noice/lsp/override.lua
@@ -11,8 +11,19 @@ function M.setup()
   if Config.options.lsp.override["cmp.entry.get_documentation"] then
     require("cmp.entry").get_documentation = function(self)
       local item = self:get_completion_item()
+      local filetype = self.context.filetype
+      local docs = {}
+      if item.detail and item.detail ~= '' then
+        table.insert(docs, {
+          kind = 'markdown',
+          value = ("```%s\n%s\n```"):format(filetype, item.detail),
+        })
+      end
       if item.documentation then
-        return Format.format_markdown(item.documentation)
+        table.insert(docs, item.documentation)
+      end
+      if not vim.tbl_isempty(docs) then
+        return Format.format_markdown(docs)
       end
       return {}
     end


### PR DESCRIPTION
The LSP completion docs are currently missing the property `detail` docs.

First screenshot shows the current experience. It is missing the information on what `type` the completion item is.
![Screenshot 2022-11-18 at 9 20 31 AM](https://user-images.githubusercontent.com/43035978/202726817-8f0c1ab9-ffe3-41c9-b5b4-82d7e7d9bc6e.png)

This second screenshot shows after applying the fix in this PR. You can see the detail displayed.
![Screenshot 2022-11-18 at 9 22 25 AM](https://user-images.githubusercontent.com/43035978/202726803-426fd07b-52b1-450e-b509-b8b503bd4921.png)