### PR TITLE
feat(config): add calculator to cmdline formats

### DIFF
--- a/lua/noice/config/init.lua
+++ b/lua/noice/config/init.lua
@@ -26,6 +26,7 @@ function M.defaults()
         filter = { pattern = "^:%s*!", icon = "$", lang = "bash" },
         lua = { pattern = "^:%s*lua%s+", icon = "", lang = "lua" },
         help = { pattern = "^:%s*he?l?p?%s+", icon = "" },
+        calculator = { pattern = "^=", icon = "", lang = "vimnormal" },
         input = {}, -- Used by input()
         -- lua = false, -- to disable a format, set to `false`
       },


### PR DESCRIPTION
Show proper prompt for the expression register. Press `<c-r>=` in insert mode to see how it looks like.

![demo](https://user-images.githubusercontent.com/91974155/203815599-99252d7d-c23f-4dfd-9a05-07b99b419405.png)