### PR TITLE
add `cmdline_output_to_split` preset to docs/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Check the [wiki](https://github.com/folke/noice.nvim/wiki/Configuration-Recipes)
     long_message_to_split = false, -- long messages will be sent to a split
     inc_rename = false, -- enables an input dialog for inc-rename.nvim
     lsp_doc_border = false, -- add a border to hover docs and signature help
+    cmdline_output_to_split = false, -- send the output of a command you executed in the cmdline to a split
   },
   throttle = 1000 / 30, -- how frequently does Noice need to check for ui updates? This has no effect when in blocking mode.
   ---@type NoiceConfigViews

--- a/doc/noice.nvim.txt
+++ b/doc/noice.nvim.txt
@@ -324,6 +324,7 @@ for configuration recipes.
         long_message_to_split = false, -- long messages will be sent to a split
         inc_rename = false, -- enables an input dialog for inc-rename.nvim
         lsp_doc_border = false, -- add a border to hover docs and signature help
+        cmdline_output_to_split = false, -- send the output of a command you executed in the cmdline to a split
       },
       throttle = 1000 / 30, -- how frequently does Noice need to check for ui updates? This has no effect when in blocking mode.
       ---@type NoiceConfigViews


### PR DESCRIPTION
`cmdline_output_to_split` is only passively referenced in the [Views](https://github.com/folke/noice.nvim#-views) section... 

cmdline_output | split | split used by config.presets.cmdline_output_to_split
-- | -- | --

...but not called out as an available option in the [Configuration](https://github.com/folke/noice.nvim#-views) section.

Though, if you're willing to consider, I think changing the suffix of this preset (and the `  long_message_to_split`) from `_to_split` to `_to_cmdline_output` makes more sense, since that's what it actually does. Since a user has the ability to change the view for `cmdline_output`, this naming choice can easily fall apart, likely causing more confusion than it's worth.

It also begs the question of whether or not this preset should even exist, IMO. Shouldn't all `cmdline_output` go to where the user has `cmdline_output` specified? That being said, I understand it's just a nice-to-have preset, so keeping it around isn't really a bad thing, even though I'd still recommend changing the suffix if it does stick around.

Cheers! Dank je for great plugin. I've picked up on a few other bugs that I'll make tickets/PRs for when I have the time!




