### PR TITLE
Allow mapping `<esc>`

### DIFF
--- a/lua/noice/message/init.lua
+++ b/lua/noice/message/init.lua
@@ -65,7 +65,7 @@ function Message:focus()
   if win then
     vim.api.nvim_set_current_win(win)
     -- switch to normal mode
-    vim.api.nvim_input("<esc>")
+	vim.cmd("stopinsert")
     return true
   end
 end


### PR DESCRIPTION
Before this change, adding `<esc>` to `lsp.documentation.close.keys` would result in the window being closed immediately after getting focus.