### PR TITLE
Add a lazy.nvim installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,25 @@ call plug#end()
 lua require("noice").setup()
 
 ```
+</details>
+
+<details><summary>lazy.nvim</summary>
+
+```lua
+-- lazy.nvim
+{
+  "folke/noice.nvim",
+  config = function()
+    require("noice").setup({
+      -- add any options here
+    })
+  end,
+  dependencies = {
+    { "MunifTanjim/nui.nvim" },
+    { "rcarriga/nvim-notify" },
+  },
+}
+```
 
 </details>
 


### PR DESCRIPTION
Might be a good idea to help me add "recommendation" comments to properly load noice in a lazy fashion, since you have something about `module=` for `packer` that I don't understand.