### PR TITLE
fix: highlight to end of block

### DIFF
--- a/lua/noice/text/block.lua
+++ b/lua/noice/text/block.lua
@@ -28,7 +28,7 @@ end
 function Block:content()
   return table.concat(
     vim.tbl_map(
-      ---@param line NuiLine
+    ---@param line NuiLine
       function(line)
         return line:content()
       end,
@@ -69,7 +69,7 @@ function Block:highlight(bufnr, ns_id, linenr_start)
   self:_fix_extmarks()
   linenr_start = linenr_start or 1
   Highlight.update()
-  for _, line in ipairs(self._lines) do
+  for _, line in ipairs(self._lines[#self._lines]) do
     line:highlight(bufnr, ns_id, linenr_start)
     linenr_start = linenr_start + 1
   end


### PR DESCRIPTION
Hey folke,

I recently ran into a issue where the text is not fully highlighted in nvim-notify compact mode. (See https://github.com/rcarriga/nvim-notify/issues/171). This comment https://github.com/rcarriga/nvim-notify/issues/171#issuecomment-1448410610 has the steps to reproduce the problem.

I dug into this and it looks like this issue is actually in noice. Below are the screenshots before and after the change.
## before
![Screenshot 2023-03-01 at 10 58 57 PM](https://user-images.githubusercontent.com/10135646/222329144-db054211-3d8d-4ca2-a706-3dae376407fa.png)
## after
![Screenshot 2023-03-01 at 11 10 39 PM](https://user-images.githubusercontent.com/10135646/222329167-20c66278-bd6b-42f6-95f3-01ec878543fd.png)

This was a bit of poking around and trial and error. I am not sure if this is the correct approach, please let me know what you think.

Thanks for all the amazing plugins 👍 