### PR TITLE
feat(cmdline): Add format for := lua expr

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ Check the [wiki](https://github.com/folke/noice.nvim/wiki/Configuration-Recipes)
       search_down = { kind = "search", pattern = "^/", icon = " ", lang = "regex" },
       search_up = { kind = "search", pattern = "^%?", icon = " ", lang = "regex" },
       filter = { pattern = "^:%s*!", icon = "$", lang = "bash" },
-      lua = { pattern = "^:%s*lua%s+", icon = "", lang = "lua" },
-      lua_expr = { pattern = "^:%s*=%s+", icon = "", lang = "lua" },
+      lua = { pattern = { "^:%s*lua%s+", "^:%s*lua%s*=%s*", "^:%s*=%s*" }, icon = "", lang = "lua" },
       help = { pattern = "^:%s*he?l?p?%s+", icon = "" },
       input = {}, -- Used by input()
       -- lua = false, -- to disable a format, set to `false`

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Check the [wiki](https://github.com/folke/noice.nvim/wiki/Configuration-Recipes)
       search_up = { kind = "search", pattern = "^%?", icon = " ", lang = "regex" },
       filter = { pattern = "^:%s*!", icon = "$", lang = "bash" },
       lua = { pattern = "^:%s*lua%s+", icon = "", lang = "lua" },
+      lua_expr = { pattern = "^:%s*=%s+", icon = "", lang = "lua" },
       help = { pattern = "^:%s*he?l?p?%s+", icon = "" },
       input = {}, -- Used by input()
       -- lua = false, -- to disable a format, set to `false`

--- a/lua/noice/config/init.lua
+++ b/lua/noice/config/init.lua
@@ -10,9 +10,9 @@ function M.defaults()
   ---@class NoiceConfig
   local defaults = {
     cmdline = {
-      enabled = true, -- enables the Noice cmdline UI
+      enabled = true,         -- enables the Noice cmdline UI
       view = "cmdline_popup", -- view for rendering the cmdline. Change to `cmdline` to get a classic cmdline at the bottom
-      opts = {}, -- global options for the cmdline. See section on views
+      opts = {},              -- global options for the cmdline. See section on views
       ---@type table<string, CmdlineFormat>
       format = {
         -- conceal: (default=true) This will hide the text in the cmdline that matches the pattern.
@@ -25,6 +25,7 @@ function M.defaults()
         search_up = { kind = "search", pattern = "^%?", icon = " ", lang = "regex" },
         filter = { pattern = "^:%s*!", icon = "$", lang = "bash" },
         lua = { pattern = "^:%s*lua%s+", icon = "", lang = "lua" },
+        lua_expr = { pattern = "^:%s*=%s+", icon = "", lang = "lua" },
         help = { pattern = "^:%s*he?l?p?%s+", icon = "" },
         calculator = { pattern = "^=", icon = "", lang = "vimnormal" },
         input = {}, -- Used by input()
@@ -34,15 +35,15 @@ function M.defaults()
     messages = {
       -- NOTE: If you enable messages, then the cmdline is enabled automatically.
       -- This is a current Neovim limitation.
-      enabled = true, -- enables the Noice messages UI
-      view = "notify", -- default view for messages
-      view_error = "notify", -- view for errors
-      view_warn = "notify", -- view for warnings
-      view_history = "messages", -- view for :messages
+      enabled = true,              -- enables the Noice messages UI
+      view = "notify",             -- default view for messages
+      view_error = "notify",       -- view for errors
+      view_warn = "notify",        -- view for warnings
+      view_history = "messages",   -- view for :messages
       view_search = "virtualtext", -- view for search count messages. Set to `false` to disable
     },
     popupmenu = {
-      enabled = true, -- enables the Noice popupmenu UI
+      enabled = true,  -- enables the Noice popupmenu UI
       ---@type 'nui'|'cmp'
       backend = "nui", -- backend to use to show regular cmdline completions
       ---@type NoicePopupmenuItemKind|false
@@ -69,7 +70,7 @@ function M.defaults()
             { error = true },
             { warning = true },
             { event = "msg_show", kind = { "" } },
-            { event = "lsp", kind = "message" },
+            { event = "lsp",      kind = "message" },
           },
         },
       },
@@ -83,7 +84,7 @@ function M.defaults()
             { error = true },
             { warning = true },
             { event = "msg_show", kind = { "" } },
-            { event = "lsp", kind = "message" },
+            { event = "lsp",      kind = "message" },
           },
         },
         filter_opts = { count = 1 },
@@ -130,7 +131,7 @@ function M.defaults()
         enabled = true,
         view = nil, -- when nil, use defaults from documentation
         ---@type NoiceViewOptions
-        opts = {}, -- merged with defaults from documentation
+        opts = {},  -- merged with defaults from documentation
       },
       signature = {
         enabled = true,
@@ -138,11 +139,11 @@ function M.defaults()
           enabled = true,
           trigger = true, -- Automatically show signature help when typing a trigger character from the LSP
           luasnip = true, -- Will open signature help when jumping to Luasnip insert nodes
-          throttle = 50, -- Debounce lsp signature help request by 50ms
+          throttle = 50,  -- Debounce lsp signature help request by 50ms
         },
-        view = nil, -- when nil, use defaults from documentation
+        view = nil,       -- when nil, use defaults from documentation
         ---@type NoiceViewOptions
-        opts = {}, -- merged with defaults from documentation
+        opts = {},        -- merged with defaults from documentation
       },
       message = {
         -- Messages shown by lsp servers
@@ -164,7 +165,7 @@ function M.defaults()
     },
     markdown = {
       hover = {
-        ["|(%S-)|"] = vim.cmd.help, -- vim help links
+        ["|(%S-)|"] = vim.cmd.help,                       -- vim help links
         ["%[.-%]%((%S-)%)"] = require("noice.util").open, -- markdown links
       },
       highlights = {
@@ -189,14 +190,14 @@ function M.defaults()
     presets = {
       -- you can enable a preset by setting it to true, or a table that will override the preset config
       -- you can also add custom presets that you can enable/disable with enabled=true
-      bottom_search = false, -- use a classic bottom cmdline for search
-      command_palette = false, -- position the cmdline and popupmenu together
-      long_message_to_split = false, -- long messages will be sent to a split
-      inc_rename = false, -- enables an input dialog for inc-rename.nvim
-      lsp_doc_border = false, -- add a border to hover docs and signature help
+      bottom_search = false,           -- use a classic bottom cmdline for search
+      command_palette = false,         -- position the cmdline and popupmenu together
+      long_message_to_split = false,   -- long messages will be sent to a split
+      inc_rename = false,              -- enables an input dialog for inc-rename.nvim
+      lsp_doc_border = false,          -- add a border to hover docs and signature help
       cmdline_output_to_split = false, -- send the output of a command you executed in the cmdline to a split
     },
-    throttle = 1000 / 30, -- how frequently does Noice need to check for ui updates? This has no effect when in blocking mode.
+    throttle = 1000 / 30,              -- how frequently does Noice need to check for ui updates? This has no effect when in blocking mode.
     ---@type NoiceConfigViews
     views = {}, ---@see section on views
     ---@type NoiceRouteConfig[]

--- a/lua/noice/config/init.lua
+++ b/lua/noice/config/init.lua
@@ -10,9 +10,9 @@ function M.defaults()
   ---@class NoiceConfig
   local defaults = {
     cmdline = {
-      enabled = true,         -- enables the Noice cmdline UI
+      enabled = true, -- enables the Noice cmdline UI
       view = "cmdline_popup", -- view for rendering the cmdline. Change to `cmdline` to get a classic cmdline at the bottom
-      opts = {},              -- global options for the cmdline. See section on views
+      opts = {}, -- global options for the cmdline. See section on views
       ---@type table<string, CmdlineFormat>
       format = {
         -- conceal: (default=true) This will hide the text in the cmdline that matches the pattern.
@@ -35,15 +35,15 @@ function M.defaults()
     messages = {
       -- NOTE: If you enable messages, then the cmdline is enabled automatically.
       -- This is a current Neovim limitation.
-      enabled = true,              -- enables the Noice messages UI
-      view = "notify",             -- default view for messages
-      view_error = "notify",       -- view for errors
-      view_warn = "notify",        -- view for warnings
-      view_history = "messages",   -- view for :messages
+      enabled = true, -- enables the Noice messages UI
+      view = "notify", -- default view for messages
+      view_error = "notify", -- view for errors
+      view_warn = "notify", -- view for warnings
+      view_history = "messages", -- view for :messages
       view_search = "virtualtext", -- view for search count messages. Set to `false` to disable
     },
     popupmenu = {
-      enabled = true,  -- enables the Noice popupmenu UI
+      enabled = true, -- enables the Noice popupmenu UI
       ---@type 'nui'|'cmp'
       backend = "nui", -- backend to use to show regular cmdline completions
       ---@type NoicePopupmenuItemKind|false
@@ -70,7 +70,7 @@ function M.defaults()
             { error = true },
             { warning = true },
             { event = "msg_show", kind = { "" } },
-            { event = "lsp",      kind = "message" },
+            { event = "lsp", kind = "message" },
           },
         },
       },
@@ -84,7 +84,7 @@ function M.defaults()
             { error = true },
             { warning = true },
             { event = "msg_show", kind = { "" } },
-            { event = "lsp",      kind = "message" },
+            { event = "lsp", kind = "message" },
           },
         },
         filter_opts = { count = 1 },
@@ -131,7 +131,7 @@ function M.defaults()
         enabled = true,
         view = nil, -- when nil, use defaults from documentation
         ---@type NoiceViewOptions
-        opts = {},  -- merged with defaults from documentation
+        opts = {}, -- merged with defaults from documentation
       },
       signature = {
         enabled = true,
@@ -139,11 +139,11 @@ function M.defaults()
           enabled = true,
           trigger = true, -- Automatically show signature help when typing a trigger character from the LSP
           luasnip = true, -- Will open signature help when jumping to Luasnip insert nodes
-          throttle = 50,  -- Debounce lsp signature help request by 50ms
+          throttle = 50, -- Debounce lsp signature help request by 50ms
         },
-        view = nil,       -- when nil, use defaults from documentation
+        view = nil, -- when nil, use defaults from documentation
         ---@type NoiceViewOptions
-        opts = {},        -- merged with defaults from documentation
+        opts = {}, -- merged with defaults from documentation
       },
       message = {
         -- Messages shown by lsp servers
@@ -165,7 +165,7 @@ function M.defaults()
     },
     markdown = {
       hover = {
-        ["|(%S-)|"] = vim.cmd.help,                       -- vim help links
+        ["|(%S-)|"] = vim.cmd.help, -- vim help links
         ["%[.-%]%((%S-)%)"] = require("noice.util").open, -- markdown links
       },
       highlights = {
@@ -190,14 +190,14 @@ function M.defaults()
     presets = {
       -- you can enable a preset by setting it to true, or a table that will override the preset config
       -- you can also add custom presets that you can enable/disable with enabled=true
-      bottom_search = false,           -- use a classic bottom cmdline for search
-      command_palette = false,         -- position the cmdline and popupmenu together
-      long_message_to_split = false,   -- long messages will be sent to a split
-      inc_rename = false,              -- enables an input dialog for inc-rename.nvim
-      lsp_doc_border = false,          -- add a border to hover docs and signature help
+      bottom_search = false, -- use a classic bottom cmdline for search
+      command_palette = false, -- position the cmdline and popupmenu together
+      long_message_to_split = false, -- long messages will be sent to a split
+      inc_rename = false, -- enables an input dialog for inc-rename.nvim
+      lsp_doc_border = false, -- add a border to hover docs and signature help
       cmdline_output_to_split = false, -- send the output of a command you executed in the cmdline to a split
     },
-    throttle = 1000 / 30,              -- how frequently does Noice need to check for ui updates? This has no effect when in blocking mode.
+    throttle = 1000 / 30, -- how frequently does Noice need to check for ui updates? This has no effect when in blocking mode.
     ---@type NoiceConfigViews
     views = {}, ---@see section on views
     ---@type NoiceRouteConfig[]

--- a/lua/noice/config/init.lua
+++ b/lua/noice/config/init.lua
@@ -24,8 +24,7 @@ function M.defaults()
         search_down = { kind = "search", pattern = "^/", icon = " ", lang = "regex" },
         search_up = { kind = "search", pattern = "^%?", icon = " ", lang = "regex" },
         filter = { pattern = "^:%s*!", icon = "$", lang = "bash" },
-        lua = { pattern = "^:%s*lua%s+", icon = "", lang = "lua" },
-        lua_expr = { pattern = "^:%s*=%s+", icon = "", lang = "lua" },
+        lua = { pattern = { "^:%s*lua%s+", "^:%s*lua%s*=%s*", "^:%s*=%s*" }, icon = "", lang = "lua" },
         help = { pattern = "^:%s*he?l?p?%s+", icon = "" },
         calculator = { pattern = "^=", icon = "", lang = "vimnormal" },
         input = {}, -- Used by input()


### PR DESCRIPTION
Hey @folke there was a new commit on nightly https://github.com/neovim/neovim/commit/a92b38934a2d00c13ee4d1969d994da15e0857ab with a shorthand syntax `:=` for `:lua` cmdline. This feature is to match the pattern and format with the lua icon.

My autoformatter added the whitespace, let me know if you want me to remove it. 

> The `:= {expr}` syntax can be used to evaluate a lua expression, as
  a shorter form of `:lua ={expr}`. `:=` and `:[range]=` without argument
  are unchanged. However `:=#` and similar variants using |ex-flags|
  are no longer supported.