### PR TITLE
Deprecated get_query treesitter call

### DIFF
--- a/lua/noice/text/treesitter.lua
+++ b/lua/noice/text/treesitter.lua
@@ -56,7 +56,7 @@ function M.highlight(buf, ns, range, lang)
       return
     end
 
-    local highlighter_query = vim.treesitter.query.get_query(tree:lang(), "highlights")
+    local highlighter_query = vim.treesitter.query.get(tree:lang(), "highlights")
 
     -- Some injected languages may not have highlight queries.
     if not highlighter_query then


### PR DESCRIPTION
Hi! Thanks for this great library! I got a message (from this library itself funnily enough) saying one of the calls to treesitter is deprecated, after installing neovim from source again. Seems to be just a simple rename of the function.

It's listed in deprecations:   
```
vim.treesitter.get_query()           -> vim.treesitter.query.get()
```