### PR TITLE
fix: Move to non-deprecated `vim.treesitter` function calls

### DIFF
--- a/lua/noice/text/treesitter.lua
+++ b/lua/noice/text/treesitter.lua
@@ -56,7 +56,7 @@ function M.highlight(buf, ns, range, lang)
       return
     end
 
-    local highlighter_query = vim.treesitter.query.get_query(tree:lang(), "highlights")
+    local highlighter_query = vim.treesitter.query.get(tree:lang(), "highlights")
 
     -- Some injected languages may not have highlight queries.
     if not highlighter_query then


### PR DESCRIPTION
ref: neovim/neovim@cbbf8bd

The new function calls are not yet on neovim stable, and have just been updated. I suggest to merge this after the release of `0.9.0`.
