### PR TITLE
Fix popup's `position.row` shift for the "N" case of the "auto" anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## Changes:
+
+1. Add better "N" scaling in `lua/noice/view/nui.lua` (lines 61-62)
+
+2. Prioritize "S" anchor in `lua/noice/util/nui.lua` (lines 222-226)
+
 # 💥 Noice _(Nice, Noise, Notice)_
 
 Highly experimental plugin that completely replaces the UI for `messages`, `cmdline` and the `popupmenu`.

--- a/lua/noice/util/nui.lua
+++ b/lua/noice/util/nui.lua
@@ -219,12 +219,11 @@ end
 function M.anchor(width, height)
   local anchor = ""
   local lines_above = vim.fn.screenrow() - 1
-  local lines_below = vim.fn.winheight(0) - lines_above
 
-  if height < lines_below then
-    anchor = anchor .. "N"
-  else
+  if height < lines_above then
     anchor = anchor .. "S"
+  else
+    anchor = anchor .. "N"
   end
 
   if vim.go.columns - vim.fn.screencol() > width then

--- a/lua/noice/view/nui.lua
+++ b/lua/noice/view/nui.lua
@@ -58,6 +58,8 @@ function NuiView:update_options()
         self._opts.anchor = Util.nui.anchor(width, height)
         if self._opts.anchor:find("S") and row then
           self._opts.position.row = -row + 1
+        elseif self._opts.anchor:find("N") and row then
+          self._opts.position.row = row + 2
         end
         if self._opts.anchor:find("E") and col then
           self._opts.position.col = -col


### PR DESCRIPTION
Hello! 

I noticed that the `position.row` entry of the "N" case of the "auto" `anchor` for the `popup` entries (like `hover`) doesn't have a custom shift like the "S" case has. This causes a different offset between the two cases when setting the `position.row` values of a `popup`.

This PR adds the correct shifting for the "N" case so that a `position { row = 0, col = 0 }` is considered to be at the line above / below the current one, depending on the "S" or "N" state of the anchor. Essentially, the "auto" anchor makes the popup anchored to the current line in both directions with the same +/- differential. Negative `row` values would then start to overlap with the current line.

This behavior looks like so:

"S" anchor:
![ksnip_20230411-175442](https://user-images.githubusercontent.com/32070555/231222802-ecb44126-c109-4c62-818d-dd8c06d005b0.png)

"N" anchor:
![ksnip_20230411-175401](https://user-images.githubusercontent.com/32070555/231222878-f68bf392-d784-4c1b-884a-73249091bc8a.png)
