### PR TITLE
chore: update healthcheck

### DIFF
--- a/lua/noice/health.lua
+++ b/lua/noice/health.lua
@@ -13,19 +13,19 @@ M.log = {
   ---@class NoiceHealthLog
   checkhealth = {
     start = function(msg)
-      vim.health.report_start(msg or "noice.nvim")
+      vim.health.start(msg or "noice.nvim")
     end,
     info = function(msg, ...)
-      vim.health.report_info(msg:format(...))
+      vim.health.info(msg:format(...))
     end,
     ok = function(msg, ...)
-      vim.health.report_ok(msg:format(...))
+      vim.health.ok(msg:format(...))
     end,
     warn = function(msg, ...)
-      vim.health.report_warn(msg:format(...))
+      vim.health.warn(msg:format(...))
     end,
     error = function(msg, ...)
-      vim.health.report_error(msg:format(...))
+      vim.health.error(msg:format(...))
     end,
   },
   ---@type NoiceHealthLog

--- a/lua/noice/health.lua
+++ b/lua/noice/health.lua
@@ -5,6 +5,11 @@ local Config = require("noice.config")
 local Lsp = require("noice.lsp")
 local Treesitter = require("noice.text.treesitter")
 
+local start = vim.health.start or vim.health.report_start
+local ok = vim.health.ok or vim.health.report_ok
+local warn = vim.health.warn or vim.health.report_warn
+local error = vim.health.error or vim.health.report_error
+
 local M = {}
 
 M.checks = {}
@@ -13,19 +18,19 @@ M.log = {
   ---@class NoiceHealthLog
   checkhealth = {
     start = function(msg)
-      vim.health.start(msg or "noice.nvim")
+      start(msg or "noice.nvim")
     end,
     info = function(msg, ...)
-      vim.health.info(msg:format(...))
+      info(msg:format(...))
     end,
     ok = function(msg, ...)
-      vim.health.ok(msg:format(...))
+      ok(msg:format(...))
     end,
     warn = function(msg, ...)
-      vim.health.warn(msg:format(...))
+      warn(msg:format(...))
     end,
     error = function(msg, ...)
-      vim.health.error(msg:format(...))
+      error(msg:format(...))
     end,
   },
   ---@type NoiceHealthLog


### PR DESCRIPTION
health api was changed in [#22927](https://github.com/neovim/neovim/pull/22927)

```help
- *health#report_error* *vim.health.report_error()*	Use |vim.health.error()| instead.
- *health#report_info* *vim.health.report_info()*	Use |vim.health.info()| instead.
- *health#report_ok* *vim.health.report_ok()*		Use |vim.health.ok()| instead.
- *health#report_start* *vim.health.report_start()*	Use |vim.health.start()| instead.
- *health#report_warn* *vim.health.report_warn()*	Use |vim.health.warn()| instead.
```

