### PR TITLE
fix(html): add additional html entities

### DIFF
--- a/lua/noice/text/markdown.lua
+++ b/lua/noice/text/markdown.lua
@@ -26,7 +26,7 @@ end
 
 ---@param text string
 function M.html_entities(text)
-  local entities = { nbsp = "", lt = "<", gt = ">", amp = "&", quot = '"' }
+  local entities = { nbsp = "", lt = "<", gt = ">", amp = "&", quot = '"', apos = "'", ensp = " ", emsp = " " }
   for entity, char in pairs(entities) do
     text = text:gsub("&" .. entity .. ";", char)
   end

--- a/tests/text/markdown_spec.lua
+++ b/tests/text/markdown_spec.lua
@@ -172,5 +172,24 @@ local b
       { code = { "local b" }, lang = "text" },
     },
   },
+  {
+    input = [[
+
+1 &lt; 2
+3 &gt; 2
+&quot;quoted&quot;
+&apos;apos&apos;
+&ensp;&emsp;indented
+&amp;
+    ]],
+    output = {
+      { line = "1 < 2" },
+      { line = "3 > 2" },
+      { line = '"quoted"' },
+      { line = "'apos'" },
+      { line = "  indented" },
+      { line = "&" },
+    },
+  },
 }
 M.test()


### PR DESCRIPTION
Adds a few missing html entities.

Aligns with https://github.com/neovim/neovim/blob/26cc946226d96bf6b474d850b961e1060346c96f/runtime/lua/vim/lsp/util.lua#L1382

Fixes #447