### PR TITLE
safer lsp signature parameters

### DIFF
--- a/lua/noice/lsp/signature.lua
+++ b/lua/noice/lsp/signature.lua
@@ -150,10 +150,10 @@ function M:active_parameter(sig_index)
     return
   end
   local sig = self.signatures[sig_index]
-  if sig.activeParameter and sig.parameters[sig.activeParameter + 1] then
+  if sig.activeParameter and sig.parameters and sig.parameters[sig.activeParameter + 1] then
     return sig.parameters[sig.activeParameter + 1]
   end
-  if self.activeParameter and sig.parameters[self.activeParameter + 1] then
+  if self.activeParameter and sig.parameters and sig.parameters[self.activeParameter + 1] then
     return sig.parameters[self.activeParameter + 1]
   end
   return sig.parameters and sig.parameters[1] or nil


### PR DESCRIPTION
I noticed the same issue as described in https://github.com/folke/noice.nvim/issues/162 come up for me while using `nimlsp`. 

This adds checks for the existence of  `sig.parameters` before trying to index it.