### PR TITLE
fix(lsp): add non-nil guard to setup function

### DIFF
--- a/lua/noice/lsp/signature.lua
+++ b/lua/noice/lsp/signature.lua
@@ -54,7 +54,9 @@ function M.setup()
     vim.api.nvim_create_autocmd("LspAttach", {
       group = vim.api.nvim_create_augroup("noice_lsp_signature", { clear = true }),
       callback = function(args)
-        M.on_attach(args.buf, vim.lsp.get_client_by_id(args.data.client_id))
+        if args.data ~= nil then
+          M.on_attach(args.buf, vim.lsp.get_client_by_id(args.data.client_id))
+        end
       end,
     })
   end


### PR DESCRIPTION
In some circumstances, the arguments of autocommand callback hold a `nil` in `data` field.
It's better to skip it.