### PR TITLE
Wrap text in telescope's previewer

### DIFF
--- a/lua/telescope/_extensions/noice.lua
+++ b/lua/telescope/_extensions/noice.lua
@@ -50,6 +50,8 @@ function M.previewer()
   return previewers.new_buffer_previewer({
     title = "Message",
     define_preview = function(self, entry, _status)
+      vim.api.nvim_win_set_option(self.state.winid, "wrap", true)
+
       ---@type NoiceMessage
       local message = Format.format(entry.message, "telescope_preview")
       message:render(self.state.bufnr, Config.ns)


### PR DESCRIPTION
A [Telescope](https://github.com/nvim-telescope/telescope.nvim) picker is a great way for previewing diagnostics, but is problematic when previewing long diagnostic strings, as it only allows vertical scrolling.

Setting the _'wrap'_ option in the previewer's window allows viewing the whole diagnostic message, even when it is longer than the window's width.