### PR TITLE
Extends NerdFont-less part of the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,25 @@ Check the [wiki](https://github.com/folke/noice.nvim/wiki/Configuration-Recipes)
         help = { icon = "?" },
       },
     },
+    format = {
+      level = {
+        icons = {
+          error = "✖",
+          warn = "▼",
+          info = "●",
+        },
+      },
+    },
+    popupmenu = {
+      kind_icons = false,
+    },
+    inc_rename = {
+      cmdline = {
+        format = {
+          IncRename = { icon = "⟳" }
+        },
+      },
+    },
   })
 ```
 


### PR DESCRIPTION
This PR extends the part of README covering how to configure Noice for use _without_ a Nerd Font.

I've believe I have covered all the instances of Nerd Font use in the config but I may have missed something.
