### PR TITLE
fix: progress use vim.lsp.get_client_by_id

### DIFF
--- a/lua/noice/lsp/progress.lua
+++ b/lua/noice/lsp/progress.lua
@@ -35,7 +35,7 @@ function M.progress(_, msg, info)
 
   local message = M._progress[id]
   if not message then
-    local client = vim.lsp.get_active_clients({ id = info.client_id })[1]
+    local client = vim.lsp.get_client_by_id(info.client_id)
     -- should not happen, but it does for some reason
     if not client then
       return
@@ -77,7 +77,7 @@ end
 function M._update()
   if not vim.tbl_isempty(M._progress) then
     for id, message in pairs(M._progress) do
-      local client = vim.lsp.get_active_clients({ id = message.opts.progress.client_id })[1]
+      local client = vim.lsp.get_client_by_id(message.opts.progress.client_id)
       if not client then
         M.close(id)
       end


### PR DESCRIPTION
Some language servers are not in active list until initialization is done. 
For example clojure_lsp sends `$/progress` messages and activates itself (i.e. becomes available as active client) only when initialization is complete. In this case `get_active_clients` returns empty table. But `get_client_by_id` returns clojure client.

This PR replaces `vim.lsp.get_active_clients` with `vim.lsp.get_client_by_id` in progress handler.