### PR TITLE
fix(lsp): allow whitespace info string in markdown

### DIFF
--- a/lua/noice/text/markdown.lua
+++ b/lua/noice/text/markdown.lua
@@ -92,7 +92,7 @@ function M.parse(text, opts)
       end
     elseif M.is_code_block(line) then
       ---@type string
-      local lang = line:match("```(%S+)") or opts.ft or "text"
+      local lang = line:match("```%s*(%S+)") or opts.ft or "text"
       local block = { lang = lang, code = {} }
       while lines[l + 1] and not M.is_code_block(lines[l + 1]) do
         table.insert(block.code, lines[l + 1])

--- a/tests/text/markdown_spec.lua
+++ b/tests/text/markdown_spec.lua
@@ -131,9 +131,27 @@ local b
   {
     input = [[
 
-   *** 
+   ***
 
     ```lua
+local a
+    ```
+
+    ---
+
+    ]],
+    output = {
+      { line = "---" },
+      { code = { "local a" }, lang = "lua" },
+      { line = "---" },
+    },
+  },
+  {
+    input = [[
+
+   ***
+
+    ```   lua
 local a
     ```
 


### PR DESCRIPTION
Hey folke, I recently made an upstream change for parsing the code fence language: https://github.com/neovim/neovim/pull/24364

This is the same fix for noice 🙂.