### PR TITLE
fix: read conceal setting after sorting

### DIFF
--- a/lua/noice/ui/cmdline.lua
+++ b/lua/noice/ui/cmdline.lua
@@ -86,7 +86,7 @@ function Cmdline:get_format()
       -- if match and cmdline pos is visible
       if from and self.state.pos >= to - 1 then
         ret[#ret + 1] = {
-          offset = format.conceal and to or 0,
+          offset = to or 0,
           format = format,
         }
       end
@@ -97,7 +97,7 @@ function Cmdline:get_format()
   end)
   local format = ret[1]
   if format then
-    self.offset = format.offset
+    self.offset = format.format.conceal and format.offset or 0
     return format.format
   end
   self.offset = 0


### PR DESCRIPTION
Fixes #557 

The explanation of the fix is that if `format.conceal` is `true`, then all offsets are set to 0 and then the matched pattern won't be the longest one (so if one types `:lua`, the pattern for `^:` matches instead of `^:lua`). Once sorting is done, then the offset is correctly applied based on `format.conceal`.

I manually tested this with and without concealing but I might appreciate a quick sanity check ;) @folke 