### PR TITLE
fix: accept preset as a table

### DIFF
--- a/lua/noice/config/preset.lua
+++ b/lua/noice/config/preset.lua
@@ -23,7 +23,7 @@ function M.load(name, preset)
     return Util.panic("Unknown preset " .. name)
   end
 
-  preset = vim.tbl_deep_extend("force", {}, M.presets[name], type(preset) == "table" and preset or {})
+  preset = vim.tbl_deep_extend("force", {}, M.presets[name] or {}, type(preset) == "table" and preset or {})
   ---@cast preset NoicePreset
 
   if preset.enabled == false then


### PR DESCRIPTION
The following config fails:

```
require("noice").setup({
  presets = {
    foo = {}
  }
})
```

with the error `"expected table, got nil"`

However, according to the doc (and the code) it should be acceptable to use a table in `presents`, the parameter `presets` is:
`@class NoicePresets: table<string, NoicePreset|boolean>`

This small PR fixes this issue.