### PR TITLE
refactor: remove the fix_input hack

### DIFF
--- a/lua/noice/util/hacks.lua
+++ b/lua/noice/util/hacks.lua
@@ -18,7 +18,6 @@ end
 function M.enable()
   M.reset_augroup()
   M.fix_incsearch()
-  M.fix_input()
   M.fix_redraw()
   M.fix_cmp()
   M.fix_vim_sleuth()
@@ -139,68 +138,6 @@ function M.fix_redraw()
     vim.api.nvim_cmd = nvim_cmd
     vim.api.nvim_command = nvim_command
     vim.api.nvim_exec = nvim_exec
-  end)
-end
-
----@see https://github.com/neovim/neovim/issues/20311
-M.before_input = false
-function M.fix_input()
-  local function wrap(fn, skip, redirect)
-    return function(...)
-      if skip and skip(...) then
-        return fn(...)
-      end
-
-      local Manager = require("noice.message.manager")
-
-      -- do any updates now before blocking
-      M.before_input = true
-      Router.update()
-
-      if redirect then
-        require("noice.ui").redirect()
-      end
-
-      if not redirect then
-        M.hide_cursor()
-      end
-
-      ---@type boolean, any
-      local ok, ret = pcall(fn, ...)
-
-      if not redirect then
-        M.show_cursor()
-      end
-
-      -- clear any message right after input
-      Manager.clear({ event = "msg_show", kind = { "echo", "echomsg", "" } })
-
-      M.before_input = false
-      if ok then
-        return ret
-      end
-      error(ret)
-    end
-  end
-
-  local function skip(expr)
-    return expr ~= nil
-  end
-  local getchar = vim.fn.getchar
-  local getcharstr = vim.fn.getcharstr
-  local inputlist = vim.fn.inputlist
-  -- local confirm = vim.fn.confirm
-
-  vim.fn.getchar = wrap(vim.fn.getchar, skip)
-  vim.fn.getcharstr = wrap(vim.fn.getcharstr, skip)
-  vim.fn.inputlist = wrap(vim.fn.inputlist, nil)
-  -- vim.fn.confirm = wrap(vim.fn.confirm, nil)
-
-  table.insert(M._disable, function()
-    vim.fn.getchar = getchar
-    vim.fn.getcharstr = getcharstr
-    vim.fn.inputlist = inputlist
-    -- vim.fn.confirm = confirm
   end)
 end
 

--- a/lua/noice/util/init.lua
+++ b/lua/noice/util/init.lua
@@ -210,7 +210,6 @@ function M.is_blocking(opts)
 
   local reason = opts.blocking and mode.blocking and "blocking"
     or opts.mode and blocking_mode and ("mode:" .. mode.mode)
-    or opts.input and Hacks.before_input and "input"
     or opts.redraw and Hacks.inside_redraw and "redraw"
     or #require("noice.ui.cmdline").cmdlines > 0 and "cmdline"
     or nil


### PR DESCRIPTION
This was probably added for a good reason in the past, but wrapping these input functions is now [causing issues with other plugins](https://github.com/echasnovski/mini.nvim/issues/430#issuecomment-1704312715) (and as far as I was able to test, it doesn't seem necessary anymore?). 

As an example, [`mini.clue`](https://github.com/echasnovski/mini.nvim/blob/3a3e19d7b7850e711485b8adde73ba44789f2cf6/lua/mini/clue.lua#L1906) uses `getcharstr` to get the next typed key, but it's problematic when using the [submode feature](https://github.com/echasnovski/mini.nvim/blob/3a3e19d7b7850e711485b8adde73ba44789f2cf6/lua/mini/clue.lua#L346-L444). This is because when using submodes, `mini.clue` will enter a kind of a "pending" mode until the submode is exited, but `noice` hides the cursor while in such state.

Removing this code didn't cause any noticeable problems locally. `noice` already [hides the cursor when entering command-line mode](https://github.com/folke/noice.nvim/blob/74c2902146b080035beb19944baf6f014a954720/lua/noice/ui/cmdline.lua#L254), and even other plugins like [`bufferline`](https://github.com/akinsho/bufferline.nvim/blob/9961d87bb3ec008213c46ba14b3f384a5f520eb5/lua/bufferline/pick.lua#L23) and [`flash`](https://github.com/folke/flash.nvim/blob/8a8e74922a383c253b7f92e042b749150140c8d1/lua/flash/util.lua#L44) all seem to work as expected.