### PR TITLE
fix: check item.detail is type of table

### DIFF
--- a/lua/noice/lsp/override.lua
+++ b/lua/noice/lsp/override.lua
@@ -16,14 +16,18 @@ function M.setup()
 
         local lines = item.documentation and Format.format_markdown(item.documentation) or {}
         local ret = table.concat(lines, "\n")
+        local detail = item.detail
+        if detail and type(detail) == "table" then
+          detail = table.concat(detail, "\n")
+        end
 
-        if item.detail and not ret:find(item.detail, 1, true) then
+        if detail and not ret:find(detail, 1, true) then
           local ft = self.context.filetype
           local dot_index = string.find(ft, "%.")
           if dot_index ~= nil then
             ft = string.sub(ft, 0, dot_index - 1)
           end
-          ret = ("```%s\n%s\n```\n%s"):format(ft, vim.trim(item.detail), ret)
+          ret = ("```%s\n%s\n```\n%s"):format(ft, vim.trim(detail), ret)
         end
         return vim.split(ret, "\n")
       end


### PR DESCRIPTION
<img width="1461" alt="CleanShot 2023-09-18 at 16 54 38@2x" src="https://github.com/folke/noice.nvim/assets/10345518/24244abf-6e19-4d0f-b155-7e63bf963f46">

https://github.com/folke/noice.nvim/blob/74c2902146b080035beb19944baf6f014a954720/lua/noice/lsp/override.lua#L20

`item.detail` sometimes is type of **table** and it will cause `ret:find` function throw a exception.