### PR TITLE
fix substitution flickering?

### DIFF
--- a/lua/noice/message/init.lua
+++ b/lua/noice/message/init.lua
@@ -65,7 +65,7 @@ function Message:focus()
   if win then
     vim.api.nvim_set_current_win(win)
     -- switch to normal mode
-	vim.cmd("stopinsert")
+    vim.cmd("stopinsert")
     return true
   end
 end

--- a/lua/noice/util/hacks.lua
+++ b/lua/noice/util/hacks.lua
@@ -233,13 +233,18 @@ function M.fix_cmp()
   end)
 end
 
+local redrawing = false
 function M.cmdline_force_redraw()
   if not require("noice.util.ffi").cmdpreview then
     return
   end
-
+  if redrawing then
+    return
+  end
+  redrawing = true
   vim.schedule(function()
     vim.cmd([[redraw!]])
+    redrawing = false
   end)
 end
 

--- a/lua/noice/util/hacks.lua
+++ b/lua/noice/util/hacks.lua
@@ -238,10 +238,9 @@ function M.cmdline_force_redraw()
     return
   end
 
-  -- HACK: this will trigger redraw during substitute and cmdpreview,
-  -- but when moving the cursor, the screen will be cleared until
-  -- a new character is entered
-  vim.api.nvim_input(" <bs>")
+  vim.schedule(function()
+    vim.cmd([[redraw!]])
+  end)
 end
 
 ---@type string?


### PR DESCRIPTION
i saw [this](https://github.com/hrsh7th/nvim-cmp/blob/main/lua/cmp/utils/misc.lua#L229) in nvim-cmp which uses redraw in a vim schedule to refresh the completion window in command mode.
i tried it with noice and it seems to remove the flicking from substitution.

redrawing in a command mapping seems fine. which means the schedule method should be safe.
it also hasn't crashed on me in my testing at all.