### PR TITLE
new cmdline redraw hack that doesn't flicker

### DIFF
--- a/lua/noice/message/init.lua
+++ b/lua/noice/message/init.lua
@@ -65,7 +65,7 @@ function Message:focus()
   if win then
     vim.api.nvim_set_current_win(win)
     -- switch to normal mode
-	vim.cmd("stopinsert")
+    vim.cmd("stopinsert")
     return true
   end
 end

--- a/lua/noice/ui/cmdline.lua
+++ b/lua/noice/ui/cmdline.lua
@@ -201,16 +201,11 @@ end
 ---@field screenpos {row:number, col:number} (1-0)-indexed screen position of the cmdline
 M.position = nil
 
-local old_cmdline = nil
 ---@param buf number
 ---@param line number
 ---@param byte number
 function M.on_render(_, buf, line, byte)
-   local cmdline = vim.fn.getcmdline()
-  if old_cmdline == cmdline then
-      Hacks.cmdline_force_redraw()
-   end
-   old_cmdline = cmdline
+  Hacks.cmdline_force_redraw()
   local win = vim.fn.bufwinid(buf)
   if win ~= -1 then
     -- FIXME: check with cmp

--- a/lua/noice/ui/cmdline.lua
+++ b/lua/noice/ui/cmdline.lua
@@ -201,11 +201,16 @@ end
 ---@field screenpos {row:number, col:number} (1-0)-indexed screen position of the cmdline
 M.position = nil
 
+local old_cmdline = nil
 ---@param buf number
 ---@param line number
 ---@param byte number
 function M.on_render(_, buf, line, byte)
-  Hacks.cmdline_force_redraw()
+   local cmdline = vim.fn.getcmdline()
+  if old_cmdline == cmdline then
+      Hacks.cmdline_force_redraw()
+   end
+   old_cmdline = cmdline
   local win = vim.fn.bufwinid(buf)
   if win ~= -1 then
     -- FIXME: check with cmp

--- a/lua/noice/util/hacks.lua
+++ b/lua/noice/util/hacks.lua
@@ -241,7 +241,9 @@ function M.cmdline_force_redraw()
   -- HACK: this will trigger redraw during substitute and cmdpreview,
   -- but when moving the cursor, the screen will be cleared until
   -- a new character is entered
-  vim.api.nvim_input(" <bs>")
+  local cmdline = vim.fn.getcmdline()
+  local pos = vim.fn.getcmdpos()
+  vim.api.nvim_input("<insert><left>" .. cmdline:sub(pos - 1, pos - 1) .. "<insert>")
 end
 
 ---@type string?


### PR DESCRIPTION
overstriking the character before the cursor forces a cmd preview update, without changing the cmdline and without flicker in nightly (flicker in 9.4).
`<insert><left>(character before the cursor)<insert>`
the only issue is race conditions happen while getting the character before the cursor.
and waiting for neovim to add overstrike to the return value of `mode()`

ignore the first commit.