### PR TITLE
fix: window flicker with non-silent : commands

### DIFF
--- a/lua/noice/message/init.lua
+++ b/lua/noice/message/init.lua
@@ -65,7 +65,7 @@ function Message:focus()
   if win then
     vim.api.nvim_set_current_win(win)
     -- switch to normal mode
-	vim.cmd("stopinsert")
+    vim.cmd("stopinsert")
     return true
   end
 end

--- a/lua/noice/ui/cmdline.lua
+++ b/lua/noice/ui/cmdline.lua
@@ -174,7 +174,6 @@ vim.api.nvim_create_autocmd("CmdlineLeave", {
 })
 
 function M.on_show(event, content, pos, firstc, prompt, indent, level)
-  -- cmdline_show gets called before CmdlineChanged in mappings
   if mapping_has_cr then
     return
   end

--- a/lua/noice/ui/cmdline.lua
+++ b/lua/noice/ui/cmdline.lua
@@ -156,7 +156,30 @@ end
 ---@type NoiceCmdline[]
 M.cmdlines = {}
 
+local mapping_done = false
+vim.api.nvim_create_autocmd('CmdlineChanged', {
+   pattern = "*",
+   callback = function()
+      -- While a mapping is running we dont get cmdline_show only CmdlineChanged,
+      -- but when we get cmdline_show the typeahead is empty so we have to do the checking here
+      mapping_done = vim.fn.getcharstr(1) == vim.api.nvim_replace_termcodes('<cr>', true, false, true)
+   end
+})
+
+vim.api.nvim_create_autocmd('CmdlineLeave', {
+   pattern = "*",
+   callback = function()
+      mapping_done = false
+   end
+})
+
+
+
 function M.on_show(event, content, pos, firstc, prompt, indent, level)
+   -- cmdline_show gets called before CmdlineChanged in mappings
+   if vim.fn.getchar(1) ~= 0 or mapping_done then
+      return
+   end
   local c = Cmdline({
     event = event,
     content = content,

--- a/lua/noice/ui/cmdline.lua
+++ b/lua/noice/ui/cmdline.lua
@@ -156,30 +156,28 @@ end
 ---@type NoiceCmdline[]
 M.cmdlines = {}
 
-local mapping_done = false
-vim.api.nvim_create_autocmd('CmdlineChanged', {
-   pattern = "*",
-   callback = function()
-      -- While a mapping is running we dont get cmdline_show only CmdlineChanged,
-      -- but when we get cmdline_show the typeahead is empty so we have to do the checking here
-      mapping_done = vim.fn.getcharstr(1) == vim.api.nvim_replace_termcodes('<cr>', true, false, true)
-   end
+local mapping_has_cr = false
+vim.api.nvim_create_autocmd("CmdlineChanged", {
+  pattern = "*",
+  callback = function()
+    -- While a mapping is running we dont get cmdline_show only CmdlineChanged,
+    -- but when we get cmdline_show the typeahead is empty so we have to do the checking here
+    mapping_has_cr = vim.fn.getcharstr(1) == vim.api.nvim_replace_termcodes("<cr>", true, false, true)
+  end,
 })
 
-vim.api.nvim_create_autocmd('CmdlineLeave', {
-   pattern = "*",
-   callback = function()
-      mapping_done = false
-   end
+vim.api.nvim_create_autocmd("CmdlineLeave", {
+  pattern = "*",
+  callback = function()
+    mapping_has_cr = false
+  end,
 })
-
-
 
 function M.on_show(event, content, pos, firstc, prompt, indent, level)
-   -- cmdline_show gets called before CmdlineChanged in mappings
-   if vim.fn.getchar(1) ~= 0 or mapping_done then
-      return
-   end
+  -- cmdline_show gets called before CmdlineChanged in mappings
+  if mapping_has_cr then
+    return
+  end
   local c = Cmdline({
     event = event,
     content = content,


### PR DESCRIPTION
### Problem
Misconfigured plugins that use : instead of \<Cmd\> cause the command line window to flicker.
### Solution
When the commmand line changes check if we are in a mapping if we are check if the next character is \<cr\> if it is tell the command line to not open.

The checking logic is in a CmdlineChanged autocmd, because cmdline_show gets called after the typeahead is empty.

fixes(https://github.com/folke/noice.nvim/issues/665).