### PR TITLE
fix(mini): dodge status line when cmdheight > 0

### DIFF
--- a/lua/noice/config/init.lua
+++ b/lua/noice/config/init.lua
@@ -263,6 +263,9 @@ function M.setup(options)
     end,
   })
 
+  if M.options.cmdline.enabled then
+    vim.o.cmdheight = 0
+  end
   require("noice.lsp").setup()
   M._running = true
 end

--- a/lua/noice/view/backend/mini.lua
+++ b/lua/noice/view/backend/mini.lua
@@ -31,6 +31,7 @@ end
 
 function MiniView:update_options()
   self._opts = vim.tbl_deep_extend("force", defaults, self._opts)
+  self._opts.position.row = self._opts.position.row - vim.o.cmdheight
 end
 
 ---@param message NoiceMessage


### PR DESCRIPTION
The cmdheight addition in config/init.lua is to avoid breaking the
default setup, where cmdheight is reduced to 0 after MiniView's
initialisation.

---

I'm migrating to LazyVim but I still like https://github.com/gelguy/wilder.nvim.
So I disabled noice.nvim's `cmdline` and `messages`.

But then I noticed that the LSP progress pop-ups started overlapping
with the status line, so here's a patch I managed to put together.

I'm not quite sure if this is the right fix. Feel free to trump this
with a better PR :)
