### PR TITLE
feat(popupmenu): add option to hide scrollbar in popupmenu views.

### DIFF
--- a/lua/noice/types/nui.lua
+++ b/lua/noice/types/nui.lua
@@ -34,6 +34,7 @@
 ---@field border? _.NuiBorder
 ---@field anchor? NuiAnchor|"auto"
 ---@field focusable boolean
+---@field scrollbar? boolean
 ---@field zindex? number
 
 ---@class NuiPopupOptions: NuiBaseOptions,_.NuiPopupOptions

--- a/lua/noice/ui/popupmenu/nui.lua
+++ b/lua/noice/ui/popupmenu/nui.lua
@@ -226,10 +226,13 @@ function M.create(items, opts)
   end
   vim.wo[M.menu.winid].cursorline = false
 
-  M.scroll = Scrollbar({
-    winnr = M.menu.winid,
-    padding = Util.nui.normalize_padding(opts.border),
-  })
+  if opts.scrollbar ~= false then
+    M.scroll = Scrollbar({
+      winnr = M.menu.winid,
+      padding = Util.nui.normalize_padding(opts.border),
+    })
+    M.scroll:mount()
+  end
   M.scroll:mount()
 end
 


### PR DESCRIPTION
#603  Added the `scrollbar` option which was only available for certain views, and was not utilized within the popupmenu views. With this fix, popupmenu will honour the scrollbar option as well.

```
      views = {
        popupmenu = {
          scrollbar = false,
        }
      },

```