### PR TITLE
fix: level argument in notify is optional

### DIFF
--- a/lua/noice/source/notify.lua
+++ b/lua/noice/source/notify.lua
@@ -39,7 +39,7 @@ function M.get_level(level)
 end
 
 ---@param msg string
----@param level number|string
+---@param level? number|string
 ---@param opts? table<string, any>
 function M.notify(msg, level, opts)
   if vim.in_fast_event() then


### PR DESCRIPTION
level argument defaults to `info` from `get_level` function, making `level` optional to avoid warning.