### PR TITLE
fix(input): don't filter ^M and <cr> for the command line

### DIFF
--- a/lua/noice/message/init.lua
+++ b/lua/noice/message/init.lua
@@ -65,7 +65,7 @@ function Message:focus()
   if win then
     vim.api.nvim_set_current_win(win)
     -- switch to normal mode
-	vim.cmd("stopinsert")
+    vim.cmd("stopinsert")
     return true
   end
 end

--- a/lua/noice/text/block.lua
+++ b/lua/noice/text/block.lua
@@ -10,6 +10,7 @@ local Object = require("nui.object")
 
 ---@class NoiceBlock
 ---@field _lines NuiLine[]
+---@field is_cmdline boolean?
 ---@overload fun(content?: NoiceContent|NoiceContent[], highlight?: string|table): NoiceBlock
 local Block = Object("Block")
 
@@ -110,7 +111,7 @@ function Block:_append(content, highlight)
   if #self._lines == 0 then
     table.insert(self._lines, NuiLine())
   end
-  if type(content) == "string" and true then
+  if type(content) == "string" and not self.is_cmdline then
     -- handle carriage returns. They overwrite the line from the first character
     local cr = content:match("^.*()[\r]")
     if cr then
@@ -167,8 +168,10 @@ function Block:append(contents, highlight)
       ---@type number|string|table, string
       local attr_id, text = unpack(content)
       -- msg_show messages can contain invalid \r characters
-      text = text:gsub("%^M", "\r")
-      text = text:gsub("\r\n", "\n")
+      if not self.is_cmdline then
+        text = text:gsub("%^M", "\r")
+        text = text:gsub("\r\n", "\n")
+      end
 
       ---@type string|table|nil
       local hl_group

--- a/lua/noice/text/block.lua
+++ b/lua/noice/text/block.lua
@@ -1,7 +1,6 @@
 local require = require("noice.util.lazy")
 
 local Highlight = require("noice.text.highlight")
-local Util = require("noice.util")
 local NuiLine = require("nui.line")
 local Object = require("nui.object")
 
@@ -10,7 +9,7 @@ local Object = require("nui.object")
 
 ---@class NoiceBlock
 ---@field _lines NuiLine[]
----@field is_cmdline boolean?
+---@field fix_cr boolean?
 ---@overload fun(content?: NoiceContent|NoiceContent[], highlight?: string|table): NoiceBlock
 local Block = Object("Block")
 
@@ -111,7 +110,7 @@ function Block:_append(content, highlight)
   if #self._lines == 0 then
     table.insert(self._lines, NuiLine())
   end
-  if type(content) == "string" and not self.is_cmdline then
+  if type(content) == "string" and self.fix_cr ~= false then
     -- handle carriage returns. They overwrite the line from the first character
     local cr = content:match("^.*()[\r]")
     if cr then
@@ -168,7 +167,7 @@ function Block:append(contents, highlight)
       ---@type number|string|table, string
       local attr_id, text = unpack(content)
       -- msg_show messages can contain invalid \r characters
-      if not self.is_cmdline then
+      if self.fix_cr ~= false then
         text = text:gsub("%^M", "\r")
         text = text:gsub("\r\n", "\n")
       end

--- a/lua/noice/ui/cmdline.lua
+++ b/lua/noice/ui/cmdline.lua
@@ -111,7 +111,7 @@ end
 ---@param text_only? boolean
 function Cmdline:format(message, text_only)
   local format = self:get_format()
-  message.is_cmdline = true
+  message.fix_cr = false
 
   if format.icon then
     message:append(NoiceText.virtual_text(format.icon, format.icon_hl_group))

--- a/lua/noice/ui/cmdline.lua
+++ b/lua/noice/ui/cmdline.lua
@@ -111,6 +111,7 @@ end
 ---@param text_only? boolean
 function Cmdline:format(message, text_only)
   local format = self:get_format()
+  message.is_cmdline = true
 
   if format.icon then
     message:append(NoiceText.virtual_text(format.icon, format.icon_hl_group))


### PR DESCRIPTION
I am not sure if the current approach is best, but i think other methods will result in duplicated code.
Fixes:
https://github.com/folke/noice.nvim/issues/650
https://github.com/folke/noice.nvim/issues/733