### PR TITLE
fix: scrollbar thumb position

### DIFF
--- a/lua/noice/view/scrollbar.lua
+++ b/lua/noice/view/scrollbar.lua
@@ -124,9 +124,11 @@ function Scrollbar:update()
   local thumb_height = math.floor(dim.height * dim.height / buf_height + 0.5)
   thumb_height = math.max(1, thumb_height)
 
-  local pct = vim.api.nvim_win_get_cursor(self.winnr)[1] / buf_height
+  local win_info = vim.fn.getwininfo(self.winnr)[1] or {}
+  local pct = (win_info.topline or 1) / buf_height
 
-  local thumb_offset = math.floor(pct * (dim.height - thumb_height) + 0.5)
+  local thumb_offset = math.floor(pct * dim.height + 0.5)
+  thumb_offset = math.min(dim.height - thumb_height, thumb_offset)
 
   Util.win_apply_config(self.thumb.winnr, {
     width = 1,


### PR DESCRIPTION
Calculate the position of the scrollbar thumb based on the window topline rather than the cursor position.

<details>
<summary>Without the fix</summary>

https://github.com/folke/noice.nvim/assets/5222525/2abe3933-379c-4eed-8903-1fabdb8a42e0

</details>

<details>
<summary>With the fix</summary>

https://github.com/folke/noice.nvim/assets/5222525/f2bb7358-4da3-434c-b1aa-4ca7718460bc

</details>

Fixes #759