### PR TITLE
fix: config.format doesn't work

### DIFF
--- a/lua/noice/text/format/init.lua
+++ b/lua/noice/text/format/init.lua
@@ -79,7 +79,7 @@ function M.format(message, format, opts)
   format = format or "default"
 
   if type(format) == "string" then
-    format = vim.deepcopy(FormatConfig.builtin[format])
+    format = vim.deepcopy(opts[format] or FormatConfig.builtin[format])
   end
 
   -- use existing message, with a separate _lines array


### PR DESCRIPTION
```lua
require("noice").setup {
	format = { 
		telescope = { '{date} ', '{event} ', '{title} ', '{message}' },
		telescope_preview = {
			' {date} ',
			-- '{level} ',
			'{event}',
			{ '{kind}', before = { '.', hl_group = 'NoiceFormatKind' } },
			' {title}',
			'\n [{cmdline}]',
			'\n {message}',
		},
	},
}
```

The config.format doesn't work.