### PR TITLE
fix(cmdpreview): read the variable `cmdpreview` in nvim-0.9+ on windows

### DIFF
--- a/lua/noice/util/ffi.lua
+++ b/lua/noice/util/ffi.lua
@@ -32,7 +32,7 @@ end
 return setmetatable(M, {
   __index = function(_, key)
     -- HACK: cmdpreview symbol is not available on Windows
-    if vim.fn.has("nvim-0.9.0") == 0 and key == "cmdpreview" then
+    if vim.fn.has("nvim-0.9.0") ~= 1 and key == "cmdpreview" and jit.os == "Windows" then
       return false
     end
     return M.load()[key]

--- a/lua/noice/util/ffi.lua
+++ b/lua/noice/util/ffi.lua
@@ -32,7 +32,7 @@ end
 return setmetatable(M, {
   __index = function(_, key)
     -- HACK: cmdpreview symbol is not available on Windows
-    if vim.fn.has("nvim-0.9.0") == 1 and key == "cmdpreview" and jit.os == "Windows" then
+    if vim.fn.has("nvim-0.9.0") == 0 and key == "cmdpreview" then
       return false
     end
     return M.load()[key]

--- a/lua/noice/util/ffi.lua
+++ b/lua/noice/util/ffi.lua
@@ -32,7 +32,7 @@ end
 return setmetatable(M, {
   __index = function(_, key)
     -- HACK: cmdpreview symbol is not available on Windows
-    if key == "cmdpreview" and jit.os == "Windows" then
+    if not vim.fn.has("nvim-0.9.0") and key == "cmdpreview" and jit.os == "Windows" then
       return false
     end
     return M.load()[key]

--- a/lua/noice/util/ffi.lua
+++ b/lua/noice/util/ffi.lua
@@ -32,7 +32,7 @@ end
 return setmetatable(M, {
   __index = function(_, key)
     -- HACK: cmdpreview symbol is not available on Windows
-    if not vim.fn.has("nvim-0.9.0") and key == "cmdpreview" and jit.os == "Windows" then
+    if vim.fn.has("nvim-0.9.0") == 1 and key == "cmdpreview" and jit.os == "Windows" then
       return false
     end
     return M.load()[key]


### PR DESCRIPTION
Fixes #707

Ref https://github.com/luukvbaal/statuscol.nvim/issues/33#issuecomment-1481125976