### PR TITLE
feat(progress) allow to exclude LSP clients from progress reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Check the [wiki](https://github.com/folke/noice.nvim/wiki/Configuration-Recipes)
       format_done = "lsp_progress_done",
       throttle = 1000 / 30, -- frequency to update lsp progress message
       view = "mini",
+      excluded_clients = {} -- list of LSP client names where progress should't be reported.
     },
     override = {
       -- override the default lsp markdown formatter with Noice

--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ Check the [wiki](https://github.com/folke/noice.nvim/wiki/Configuration-Recipes)
       throttle = 1000 / 30, -- Frequency to update lsp progress message
       view = "mini",
       ignored_clients = {} -- List of LSP client names to be ignored
-      max_messages = nil, -- Maximum number of messages per client at any give time
     },
     override = {
       -- override the default lsp markdown formatter with Noice

--- a/README.md
+++ b/README.md
@@ -211,9 +211,10 @@ Check the [wiki](https://github.com/folke/noice.nvim/wiki/Configuration-Recipes)
       format = "lsp_progress",
       --- @type NoiceFormat|string
       format_done = "lsp_progress_done",
-      throttle = 1000 / 30, -- frequency to update lsp progress message
+      throttle = 1000 / 30, -- Frequency to update lsp progress message
       view = "mini",
-      excluded_clients = {} -- list of LSP client names where progress should't be reported.
+      ignored_clients = {} -- List of LSP client names to be ignored
+      max_messages = 3, -- Maximum number of messages per client at any give time
     },
     override = {
       -- override the default lsp markdown formatter with Noice

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Check the [wiki](https://github.com/folke/noice.nvim/wiki/Configuration-Recipes)
       throttle = 1000 / 30, -- Frequency to update lsp progress message
       view = "mini",
       ignored_clients = {} -- List of LSP client names to be ignored
-      max_messages = 3, -- Maximum number of messages per client at any give time
+      max_messages = nil, -- Maximum number of messages per client at any give time
     },
     override = {
       -- override the default lsp markdown formatter with Noice

--- a/doc/noice.nvim.txt
+++ b/doc/noice.nvim.txt
@@ -240,7 +240,6 @@ for configuration recipes.
           throttle = 1000 / 30, -- frequency to update lsp progress message
           view = "mini",
           ignored_clients = {} -- list of LSP client names to be ignored
-          max_messages = nil, -- Maximum number of messages per client at any give time
         },
         override = {
           -- override the default lsp markdown formatter with Noice

--- a/doc/noice.nvim.txt
+++ b/doc/noice.nvim.txt
@@ -240,7 +240,7 @@ for configuration recipes.
           throttle = 1000 / 30, -- frequency to update lsp progress message
           view = "mini",
           ignored_clients = {} -- list of LSP client names to be ignored
-          max_messages = 3, -- Maximum number of messages per client at any give time
+          max_messages = nil, -- Maximum number of messages per client at any give time
         },
         override = {
           -- override the default lsp markdown formatter with Noice

--- a/doc/noice.nvim.txt
+++ b/doc/noice.nvim.txt
@@ -239,6 +239,8 @@ for configuration recipes.
           format_done = "lsp_progress_done",
           throttle = 1000 / 30, -- frequency to update lsp progress message
           view = "mini",
+          ignored_clients = {} -- list of LSP client names to be ignored
+          max_messages = 3, -- Maximum number of messages per client at any give time
         },
         override = {
           -- override the default lsp markdown formatter with Noice

--- a/lua/noice/config/init.lua
+++ b/lua/noice/config/init.lua
@@ -118,7 +118,6 @@ function M.defaults()
         throttle = 1000 / 10, -- frequency to update lsp progress message
         view = "mini",
         ignored_clients = {}, -- list of LSP client names to be ignored
-        max_messages = nil, -- Maximum number of messages per client at any give time
       },
       override = {
         -- override the default lsp markdown formatter with Noice

--- a/lua/noice/config/init.lua
+++ b/lua/noice/config/init.lua
@@ -117,6 +117,7 @@ function M.defaults()
         format_done = "lsp_progress_done",
         throttle = 1000 / 10, -- frequency to update lsp progress message
         view = "mini",
+        excluded_clients = {}
       },
       override = {
         -- override the default lsp markdown formatter with Noice

--- a/lua/noice/config/init.lua
+++ b/lua/noice/config/init.lua
@@ -118,7 +118,7 @@ function M.defaults()
         throttle = 1000 / 10, -- frequency to update lsp progress message
         view = "mini",
         ignored_clients = {}, -- list of LSP client names to be ignored
-        max_messages = 3, -- Maximum number of messages per client at any give time
+        max_messages = nil, -- Maximum number of messages per client at any give time
       },
       override = {
         -- override the default lsp markdown formatter with Noice

--- a/lua/noice/config/init.lua
+++ b/lua/noice/config/init.lua
@@ -117,7 +117,8 @@ function M.defaults()
         format_done = "lsp_progress_done",
         throttle = 1000 / 10, -- frequency to update lsp progress message
         view = "mini",
-        excluded_clients = {}
+        ignored_clients = {}, -- list of LSP client names to be ignored
+        max_messages = 3, -- Maximum number of messages per client at any give time
       },
       override = {
         -- override the default lsp markdown formatter with Noice

--- a/lua/noice/lsp/progress.lua
+++ b/lua/noice/lsp/progress.lua
@@ -12,7 +12,6 @@ local M = {}
 ---@type table<string, NoiceMessage>
 M._progress = {}
 M._running = false
-M._messages = 0
 
 ---@param data {client_id: integer, params: lsp.ProgressParams}
 function M.progress(data)
@@ -73,15 +72,9 @@ function M._update()
       end
       if message.opts.progress.kind == "end" then
         Manager.add(Format.format(message, Config.options.lsp.progress.format_done))
-        if Config.options.lsp.progress.max_messages ~= nil then
-          M._messages = M._messages - 1
-        end
       else
-        if Config.options.lsp.progress.max_messages == nil or M._messages < Config.options.lsp.progress.max_messages then
+        if Config.options.lsp.progress.max_messages == nil or #M._progress < Config.options.lsp.progress.max_messages then
           Manager.add(Format.format(message, Config.options.lsp.progress.format))
-          if Config.options.lsp.progress.max_messages ~= nil then
-            M._messages = M._messages + 1
-          end
         end
       end
     end

--- a/lua/noice/lsp/progress.lua
+++ b/lua/noice/lsp/progress.lua
@@ -26,6 +26,9 @@ function M.progress(data)
     if not client then
       return
     end
+    if vim.tbl_contains(Config.options.lsp.progress.excluded_clients, client.name) then
+      return
+    end
     message = Message("lsp", "progress")
     message.opts.progress = {
       client_id = client_id,

--- a/lua/noice/lsp/progress.lua
+++ b/lua/noice/lsp/progress.lua
@@ -12,6 +12,7 @@ local M = {}
 ---@type table<string, NoiceMessage>
 M._progress = {}
 M._running = false
+M._messages = 0
 
 ---@param data {client_id: integer, params: lsp.ProgressParams}
 function M.progress(data)
@@ -26,7 +27,7 @@ function M.progress(data)
     if not client then
       return
     end
-    if vim.tbl_contains(Config.options.lsp.progress.excluded_clients, client.name) then
+    if vim.tbl_contains(Config.options.lsp.progress.ignored_clients, client.name) then
       return
     end
     message = Message("lsp", "progress")
@@ -72,8 +73,12 @@ function M._update()
       end
       if message.opts.progress.kind == "end" then
         Manager.add(Format.format(message, Config.options.lsp.progress.format_done))
+        M._messages = M._messages - 1
       else
-        Manager.add(Format.format(message, Config.options.lsp.progress.format))
+        if M._messages < Config.options.lsp.progress.max_messages then
+          Manager.add(Format.format(message, Config.options.lsp.progress.format))
+        end
+        M._messages = M._messages + 1
       end
     end
     return

--- a/lua/noice/lsp/progress.lua
+++ b/lua/noice/lsp/progress.lua
@@ -73,9 +73,7 @@ function M._update()
       if message.opts.progress.kind == "end" then
         Manager.add(Format.format(message, Config.options.lsp.progress.format_done))
       else
-        if Config.options.lsp.progress.max_messages == nil or #M._progress < Config.options.lsp.progress.max_messages then
-          Manager.add(Format.format(message, Config.options.lsp.progress.format))
-        end
+        Manager.add(Format.format(message, Config.options.lsp.progress.format))
       end
     end
     return

--- a/lua/noice/lsp/progress.lua
+++ b/lua/noice/lsp/progress.lua
@@ -73,12 +73,16 @@ function M._update()
       end
       if message.opts.progress.kind == "end" then
         Manager.add(Format.format(message, Config.options.lsp.progress.format_done))
-        M._messages = M._messages - 1
-      else
-        if M._messages < Config.options.lsp.progress.max_messages then
-          Manager.add(Format.format(message, Config.options.lsp.progress.format))
+        if Config.options.lsp.progress.max_messages ~= nil then
+          M._messages = M._messages - 1
         end
-        M._messages = M._messages + 1
+      else
+        if Config.options.lsp.progress.max_messages == nil or M._messages < Config.options.lsp.progress.max_messages then
+          Manager.add(Format.format(message, Config.options.lsp.progress.format))
+          if Config.options.lsp.progress.max_messages ~= nil then
+            M._messages = M._messages + 1
+          end
+        end
       end
     end
     return


### PR DESCRIPTION
This PR allows to configure the LSP progress with 1 new field:

- `ignored_clients` - any client name inside the list will be excluded from LSP progress report 