### PR TITLE
fix(progress): in accordance to changes renaming `data.result` to `data.params`

### DIFF
--- a/lua/noice/lsp/progress.lua
+++ b/lua/noice/lsp/progress.lua
@@ -16,7 +16,7 @@ M._running = false
 ---@param data {client_id: integer, result: lsp.ProgressParams}
 function M.progress(data)
   local client_id = data.client_id
-  local result = data.result
+  local result = data.params
   local id = client_id .. "." .. result.token
 
   local message = M._progress[id]


### PR DESCRIPTION
Introduced in https://github.com/neovim/neovim/commit/e14e75099883e6904cf3575b612f3820cd122938