### PR TITLE
fix(hacks): remove redundancies in `show_cursor`

### DIFF
--- a/lua/noice/util/hacks.lua
+++ b/lua/noice/util/hacks.lua
@@ -284,19 +284,15 @@ function M.hide_cursor()
 end
 
 function M.show_cursor()
-  if M._guicursor then
-    if not Util.is_exiting() then
-      vim.schedule(function()
-        if M._guicursor and not Util.is_exiting() then
-          -- we need to reset all first and then wait for some time before resetting the guicursor. See #114
-          vim.go.guicursor = "a:"
-          vim.cmd.redrawstatus()
-          vim.go.guicursor = M._guicursor
-          M._guicursor = nil
-        end
-      end)
+  vim.schedule(function()
+    if M._guicursor and not Util.is_exiting() then
+      -- we need to reset all first and then wait for some time before resetting the guicursor. See #114
+      vim.go.guicursor = "a:"
+      vim.cmd.redrawstatus()
+      vim.go.guicursor = M._guicursor
+      M._guicursor = nil
     end
-  end
+  end)
 end
 
 ---@param fn fun(mod)


### PR DESCRIPTION
I was constantly running into the issue of my cursor disappearing. To get it back, I had to manually(or via a dedicated au) re-set the `gcr/guicursor` setting.

Checking the code, I see you have some redundant checks for the same condition.
`if M._guicursor` and `if not Util.is_exiting()` are both check inside and outside of the scheduled function.

The removed double checks should also result in a minor improvement reducing load.

This fix can also help with the reports that people still experience #114.