### PR TITLE
perf(message): replace vim.b.messages with lua variable

### DIFF
--- a/lua/noice/view/init.lua
+++ b/lua/noice/view/init.lua
@@ -5,6 +5,7 @@ local ConfigViews = require("noice.config.views")
 local Format = require("noice.text.format")
 local Object = require("nui.object")
 local Util = require("noice.util")
+local Message = require("noice.message")
 
 ---@class NoiceViewBaseOptions
 ---@field buf_options? table<string,any>
@@ -255,7 +256,7 @@ function View:render(buf, opts)
   end
 
   vim.api.nvim_buf_clear_namespace(buf, Config.ns, linenr - 1, -1)
-  vim.b[buf].messages = {}
+  Message._buf_messages[buf] = {}
 
   ---@type number?
   local win = vim.fn.bufwinid(buf)


### PR DESCRIPTION
## Description

Using `vim.b` variables seems slow for big tables. This PR improves performance of command output redirection (and possibly other places). From my tests this is an order of 20 sec -> 4 sec.

Also, it looks like the current code sometimes assumes that `vim.b[buf].messages` is a list of buffers, while it is a list of message ids. I also changed it from a list to a set, because it's mostly used for random access.

## Related Issue(s)

This helps in case described here: https://github.com/folke/noice.nvim/issues/332 (filetype is still applied many times, but from my recent benchmarks it seems that `vim.b.messages` had bigger impact).
