### PR TITLE
fix(cmdline): check cursor position to avoid hang on exit

### DIFF
--- a/lua/noice/ui/cmdline.lua
+++ b/lua/noice/ui/cmdline.lua
@@ -233,7 +233,15 @@ function M.fix_cursor()
   if not win or not M.real_cursor then
     return
   end
-  local cursor = { vim.api.nvim_buf_line_count(M.position.buf), M.position.cursor }
+
+  local line_count = vim.api.nvim_buf_line_count(M.position.buf)
+  local cursor_line = math.min(line_count, M.position.cursor)
+  local cursor = { cursor_line, M.position.cursor }
+
+  if cursor[1] < 1 or cursor[1] > line_count or cursor[2] < 0 then
+    return -- Exit if cursor position is invalid
+  end
+
   vim.api.nvim_win_set_cursor(win, cursor)
   local leftcol = math.max(cursor[2] - vim.api.nvim_win_get_width(win) + 1, 0)
   local view = vim.api.nvim_win_call(win, vim.fn.winsaveview)


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
  
since this [commit](https://github.com/folke/noice.nvim/commit/1698725a663aca56bcd07a0e405bc441a5f6613b), sometime when you exit neovim, it hangs for a second with a visual glitch then it exits:
[video example](https://github.com/folke/noice.nvim/issues/921#issuecomment-2254168546)

Just before neovim exits you get this error message:
```
Error executing vim.schedule lua callback: ...ocal/share/nvim/lazy/noice.nvim/lua/noice/ui/cmdline.lua:237: Cursor position outside buffer
stack traceback:
	[C]: in function 'nvim_win_set_cursor'
	...ocal/share/nvim/lazy/noice.nvim/lua/noice/ui/cmdline.lua:237: in function 'fix_cursor'
	...ocal/share/nvim/lazy/noice.nvim/lua/noice/util/hacks.lua:43: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```
So i added some checks to the `cursor` variable in the `fix_cursor()` function inside `lua/noice/ui/cmdline.lua` to check if the cursor was out of bounds and this seems to fix the issue

## Related Issue(s)
- Fixes #921 
