### PR TITLE
fix(hacks): cursor jumps in cmdline

### DIFF
--- a/lua/noice/util/hacks.lua
+++ b/lua/noice/util/hacks.lua
@@ -35,7 +35,7 @@ function M.fix_redraw()
     vim.schedule_wrap(function()
       if not Util.is_search() then
         if vim.api.nvim__redraw then
-          vim.api.nvim__redraw({ flush = true, cursor = true })
+          vim.api.nvim__redraw({ flush = true, cursor = false })
         else
           vim.cmd.redraw()
         end


### PR DESCRIPTION
fix #931 #923 

After setting the `cursor` of `nvim__redraw` to `false`.
the cursor no longer jumps, it works well for me.