### PR TITLE
fix(types): route.view can be empty / nil

### DIFF
--- a/lua/noice/message/router.lua
+++ b/lua/noice/message/router.lua
@@ -15,7 +15,7 @@ local View = require("noice.view")
 ---@field skip boolean
 
 ---@class NoiceRouteConfig
----@field view string
+---@field view? string
 ---@field filter NoiceFilter
 ---@field opts? NoiceRouteOptions|NoiceViewOptions
 


### PR DESCRIPTION
## Description
`NoiceRouteConfig.view` can be empty / `nil` as the check in `M.add()` sets it to nil if the view doesn't exist.

```lua
---@param route NoiceRouteConfig
---@param pos? number
function M.add(route, pos)
  local ret = {
    filter = route.filter,
    opts = route.opts or {},
    view = route.view and View.get_view(route.view, route.opts) or nil,
  }
  if ret.view == nil then
    ret.opts.skip = true
  end
```