### PR TITLE
fix(lsp): support mixed encoding for lsp clients

### DIFF
--- a/lua/noice/lsp/init.lua
+++ b/lua/noice/lsp/init.lua
@@ -46,19 +46,28 @@ function M.setup()
   end
 end
 
+local function make_position_params()
+  if vim.fn.has("nvim-0.11") == 1 then
+    return function(client)
+      return vim.lsp.util.make_position_params(nil, client.offset_encoding)
+    end
+  else
+    ---@diagnostic disable-next-line: missing-parameter
+    return vim.lsp.util.make_position_params()
+  end
+end
+
 function M.scroll(delta)
   return require("noice.lsp.docs").scroll(delta)
 end
 
 function M.hover()
-  ---@diagnostic disable-next-line: missing-parameter
-  local params = vim.lsp.util.make_position_params()
+  local params = make_position_params()
   vim.lsp.buf_request(0, "textDocument/hover", params, require("noice.lsp.hover").on_hover)
 end
 
 function M.signature()
-  ---@diagnostic disable-next-line: missing-parameter
-  local params = vim.lsp.util.make_position_params()
+  local params = make_position_params()
   vim.lsp.buf_request(0, "textDocument/signatureHelp", params, require("noice.lsp.signature").on_signature)
 end
 


### PR DESCRIPTION
## Description

Fixes a warning notification for the first hover/signature help notification on nightly now that `offset_encoding` is required for `make_position_params`

