### PR TITLE
fix(telescope): handle hl_group ID correctly in picker

### DIFF
--- a/lua/telescope/_extensions/noice.lua
+++ b/lua/telescope/_extensions/noice.lua
@@ -20,6 +20,10 @@ function M.display(message)
   local byte = 0
   for _, text in ipairs(line._texts) do
     local hl_group = text.extmark and text.extmark.hl_group
+    if type(hl_group) == "number" then
+      hl_group = vim.fn.synIDattr(hl_group, "name")
+    end
+
     if hl_group then
       table.insert(hl, { { byte, byte + text:length() }, hl_group })
     end


### PR DESCRIPTION
## Description

Since commit [742610e](https://github.com/folke/noice.nvim/commit/742610e9958ad4f1146983db2e7356c8105a441c), extmark's hl_group can now be specified directly as an ID. This change ensures that if the hl_group is provided as a number (ID), it is resolved to its name using `synIDattr` for correct handling.

Fixes: #1024 