### PR TITLE
fix(fzf-lua): update `update_title` and `update_scrollbar` to `update_preview_title` and `update_preview_scrollbar`

### DIFF
--- a/lua/noice/integrations/fzf.lua
+++ b/lua/noice/integrations/fzf.lua
@@ -72,8 +72,8 @@ function M.previewer(messages)
     m:render(buf, Config.ns)
 
     self:set_preview_buf(buf)
-    self.win:update_title(" Noice ")
-    self.win:update_scrollbar()
+    self.win:update_preview_title(" Noice ")
+    self.win:update_preview_scrollbar()
   end
 
   return previewer


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
`FzfWin:update_title` and `FzfWin:update_scrollbar` were changed to `FzfWin:update_preview_title` and `FzfWin:update_preview_scroolbar` since ibhagwan/fzf-lua@fc70792718d4a41101956c10ec04b6bf6a258777

It will make an error when opening message history with fzf-lua `:Noice fzf`
```
Error executing vim.schedule lua callback: ...hare/nvim/lazy/noice.nvim/lua/noice/integrations/fzf.lua:75: attempt to call method 'update__title' (a nil value)
stack traceback:
	...hare/nvim/lazy/noice.nvim/lua/noice/integrations/fzf.lua:75: in function 'populate_preview_buf'
	...hare/nvim/lazy/fzf-lua/lua/fzf-lua/previewer/builtin.lua:377: in function 'populate_preview_buf'
	...hare/nvim/lazy/fzf-lua/lua/fzf-lua/previewer/builtin.lua:394: in function ''
	vim/_editor.lua: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
Fixes #1029 