### PR TITLE
feat(fzf): fix fzf integration

### DIFF
--- a/lua/noice/integrations/fzf.lua
+++ b/lua/noice/integrations/fzf.lua
@@ -19,6 +19,9 @@ function M.entry(message)
   for _, text in ipairs(line._texts) do
     ---@type string?
     local hl_group = text.extmark and text.extmark.hl_group
+    if type(hl_group) == "number" then
+      hl_group = vim.fn.synIDattr(hl_group, "name")
+    end
     hl[#hl + 1] = hl_group and fzf.utils.ansi_from_hl(hl_group, text:content()) or text:content()
   end
   return {
@@ -72,8 +75,8 @@ function M.previewer(messages)
     m:render(buf, Config.ns)
 
     self:set_preview_buf(buf)
-    self.win:update_title(" Noice ")
-    self.win:update_scrollbar()
+    self.win:update_preview_title(" Noice ")
+    self.win:update_preview_scrollbar()
   end
 
   return previewer


### PR DESCRIPTION
## Description
`<leader>snt` wasn't working properly

- the same fzf compatibility update as https://github.com/folke/noice.nvim/pull/1034
- the hl_group update from https://github.com/folke/noice.nvim/pull/1032 but for `fzf.lua`

Those PRs should probably merged instead of this, but the hl_group update one also needs to update `lua/noice/integrations/fzf.lua`
Figured I'd submit this to bump visibility of the issue.

## Related Issue(s)

https://github.com/folke/noice.nvim/issues/1029
https://github.com/folke/noice.nvim/issues/1024


