### PR TITLE
fix(treesitter): look for lowercase parsers only

### DIFF
--- a/lua/noice/text/init.lua
+++ b/lua/noice/text/init.lua
@@ -60,6 +60,7 @@ function NoiceText:highlight(bufnr, ns_id, linenr, byte_start)
   end
 
   if self.extmark.lang then
+    self.extmark.lang = string.lower(self.extmark.lang)
     local range = { linenr - self.extmark.lines, 0, linenr, byte_start + 1 }
     if self.extmark.col then
       range[2] = byte_start + self.extmark.col - 1


### PR DESCRIPTION
## Description

This PR attempts to fix an issue with calling the treesitter has_lang function. Specifically,  when trying to use Hover via noice in an R language or quarto markdown document (.qmd) file that is working on an R file, there are issues with finding the correct R parser. 

If noice.nvim is disabled, hover works just fine for this scenario. However, when enabled, with latest neovim nightly, latest LazyVim commit and latest Noice commit, I was met with the following error:

```lua
   Error  12:03:46 notify.error noice.nvim ...y/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:143: no such language: R
```

and the full error from the log:

```lua
stack traceback:
	[C]: in function 'pcall'
	...local/share/nvim/lazy/noice.nvim/lua/noice/util/call.lua:144: in function <...local/share/nvim/lazy/noice.nvim/lua/noice/util/call.lua:143>
	[C]: in function '_create_ts_parser'
	...y/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:143: in function 'new'
	...share/nvim/lazy/noice.nvim/lua/noice/text/treesitter.lua:44: in function 'highlight'
	...local/share/nvim/lazy/noice.nvim/lua/noice/text/init.lua:69: in function 'highlight'
	...at/.local/share/nvim/lazy/nui.nvim/lua/nui/line/init.lua:58: in function 'highlight'
	...
	[C]: in function 'xpcall'
	...local/share/nvim/lazy/noice.nvim/lua/noice/util/call.lua:149: in function <...local/share/nvim/lazy/noice.nvim/lua/noice/util/call.lua:134>
	...local/share/nvim/lazy/noice.nvim/lua/noice/view/init.lua:170: in function 'display'
	.../share/nvim/lazy/noice.nvim/lua/noice/message/router.lua:214: in function <.../share/nvim/lazy/noice.nvim/lua/noice/message/router.lua:147>
	[C]: in function 'xpcall'
	...local/share/nvim/lazy/noice.nvim/lua/noice/util/call.lua:149: in function <...local/share/nvim/lazy/noice.nvim/lua/noice/util/call.lua:134>
	[C]: in function 'pcall'
	...local/share/nvim/lazy/noice.nvim/lua/noice/util/init.lua:146: in function ''
	vim/_editor.lua: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>

Tue Feb 11 12:03:46 2025
...y/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:143: no such language: R

```
I noticed in this error that it was looking for an R parser and not a lowercase r.

When I investigated deeper, it seemed like the nvim runtime applies a lower case function call to all parser names as they are added to the run time and the installed treesitter parser is an r.so not R.so. Because a hover call with a disabled noice worked, I figured we must be missing a lower casing of the parser somewhere. I was surprised this was an issue because I have not had problems with noice and hover with the other 5-6 languages I work with.

## Related Issue(s)

I didn't file an issue because I found a solution first

