### PR TITLE
feat(views): add cancel_on_enter config option to nui views

### DIFF
--- a/lua/noice/types/nui.lua
+++ b/lua/noice/types/nui.lua
@@ -15,10 +15,14 @@
 ---@class NuiBorder: _.NuiBorder
 ---@field padding? _.NuiBorderPadding|number[]
 
+---@class NuiTimeout
+---@field duration number
+---@field cancel_on_enter? boolean
+
 ---@class _.NuiBaseOptions
 ---@field relative? NuiRelative
 ---@field enter? boolean
----@field timeout? number
+---@field timeout? NuiTimeout
 ---@field buf_options? vim.bo
 ---@field win_options? vim.wo
 ---@field close? {events?:string[], keys?:string[]}

--- a/lua/noice/view/nui.lua
+++ b/lua/noice/view/nui.lua
@@ -22,13 +22,14 @@ function NuiView:init(opts)
 end
 
 function NuiView:autohide()
-  if self._opts.timeout then
-    self._timer:start(self._opts.timeout, 0, function()
-      if self._visible then
+  if self._opts.timeout.duration then
+    self._timer:start(self._opts.timeout.duration, 0, function()
+      if self._visible and not self._stay_visible then
         vim.schedule(function()
           self:hide()
         end)
       end
+      self._stay_visible = false
       self._timer:stop()
     end)
   end
@@ -115,6 +116,12 @@ function NuiView:mount()
     self._nui:map("n", self._opts.close.keys, function()
       self:hide()
     end, { remap = false, nowait = true })
+  end
+
+  if self._opts.timeout.cancel_on_enter then
+    self._nui:on("BufEnter", function()
+      self._stay_visible = true
+    end, { once = false })
   end
 end
 

--- a/lua/noice/view/nui.lua
+++ b/lua/noice/view/nui.lua
@@ -22,7 +22,7 @@ function NuiView:init(opts)
 end
 
 function NuiView:autohide()
-  if self._opts.timeout.duration then
+  if self._opts.timeout and self._opts.timeout.duration > 0 then
     self._timer:start(self._opts.timeout.duration, 0, function()
       if self._visible and not self._stay_visible then
         vim.schedule(function()
@@ -118,7 +118,7 @@ function NuiView:mount()
     end, { remap = false, nowait = true })
   end
 
-  if self._opts.timeout.cancel_on_enter then
+  if self._opts.timeout and self._opts.timeout.cancel_on_enter then
     self._nui:on("BufEnter", function()
       self._stay_visible = true
     end, { once = false })


### PR DESCRIPTION
## Description

Adds a configuration option to views with nui (split, popup) backends to allow for keeping the window open if the cursor enters it before the auto-close timeout expires (if a timeout is set, of course).

## Related Issue(s)


## Screenshots
