### PR TITLE
feat(main): add cmdline highlighting to allow for independent styling of the command (instead of forcing Statement)

### DIFF
--- a/lua/noice/config/highlights.lua
+++ b/lua/noice/config/highlights.lua
@@ -16,6 +16,7 @@ M.defaults = {
   CmdlinePopupBorder = "DiagnosticSignInfo", -- Cmdline popup border
   CmdlinePopupTitle = "DiagnosticSignInfo", -- Cmdline popup border
   CmdlinePopupBorderSearch = "DiagnosticSignWarn", -- Cmdline popup border for search
+  CmdlineCommand = "Statement", -- Highlight for the command (first word) in the cmdline
   Confirm = "Normal", -- Normal for the confirm view
   ConfirmBorder = "DiagnosticSignInfo", -- Border for the confirm view
   Cursor = "Cursor", -- Fake Cursor

--- a/lua/noice/text/syntax.lua
+++ b/lua/noice/text/syntax.lua
@@ -19,6 +19,7 @@ function M.highlight(buf, ns, range, lang)
     if not pcall(vim.cmd, string.format("syntax include %s syntax/%s.vim", group, lang)) then
       return
     end
+    
     vim.cmd(
       string.format(
         "syntax region %s start=+\\%%%dl+ end=+\\%%%dl+ contains=%s keepend",
@@ -28,6 +29,23 @@ function M.highlight(buf, ns, range, lang)
         group
       )
     )
+    
+    if lang == "vim" then
+      local ok = pcall(vim.cmd, string.format([[
+        syntax match NoiceCmdlineCommand /\v^\s*\w+/ display
+        highlight default link NoiceCmdlineCommand Statement
+      ]]))
+      
+      if ok then
+        local line = vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1]
+        if line then
+          local cmd_end = line:find("%s") or #line + 1
+          if cmd_end > 1 then
+            vim.api.nvim_buf_add_highlight(buf, ns, "NoiceCmdlineCommand", 0, 0, cmd_end - 1)
+          end
+        end
+      end
+    end
   end)
 end
 


### PR DESCRIPTION
## Description

Add support for highlighting the command portion (first word) in Vim cmdline:

- Add NoiceCmdlineCommand highlight group with default link to Statement
- Implement dedicated highlighting for command words in cmdline UI
- Add fallback direct highlighting when syntax highlighting is insufficient
- Ensure highlighting works regardless of buffer syntax state

This enhances the visual distinction between the command and its arguments, making the command line more readable and easier to understand at a glance.

## Related Issue(s)

n/a
