### PR TITLE
docs(readme): corrected unnecessary characters in Require section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Check this [tracking issue](https://github.com/folke/noice.nvim/issues/6) for a 
 - Neovim >= 0.9.0 **_(nightly highly recommended)_**
 - [nui.nvim](https://github.com/MunifTanjim/nui.nvim): used for proper rendering and multiple views
 - [nvim-notify](https://github.com/rcarriga/nvim-notify): notification view _**(optional)**_
-- a [Nerd Font](https://www.nerdfonts.com/) **_(optional)_**
+- [Nerd Font](https://www.nerdfonts.com/) **_(optional)_**
 - [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/) **_(optional, but highly recommended)_**
   used for highlighting the cmdline and lsp docs. Make sure to install the parsers for
   `vim`, `regex`, `lua`, `bash`, `markdown` and `markdown_inline`


### PR DESCRIPTION
## Description

This PR fixes a minor typo in the Requirements section of the README.
The phrase "a Nerd Font (optional)" contained an unnecessary "a," making it inconsistent with the rest of the list.
It has been corrected to "Nerd Font (optional)" for clarity and consistency.

## Related Issue(s)

N/A

## Screenshots

| Before | After |
|--------|--------|
| <img width="856" alt="image" src="https://github.com/user-attachments/assets/673a9ca5-2df2-4e18-9f61-599fb573dcd7" /> | <img width="878" alt="image" src="https://github.com/user-attachments/assets/dff40a4d-c8f6-455d-b79e-8a1130112495" /> | 
