### PR TITLE
feat(confirm): configurable alignment of choices line

### DIFF
--- a/lua/noice/config/format.lua
+++ b/lua/noice/config/format.lua
@@ -151,6 +151,9 @@ M.defaults = {
   },
   ---@class NoiceFormatOptions.confirm
   confirm = {
+    choices = {
+      align = "center",
+    },
     hl_group = {
       choice = "NoiceFormatConfirm",
       default_choice = "NoiceFormatConfirmDefault",

--- a/lua/noice/text/format/formatters.lua
+++ b/lua/noice/text/format/formatters.lua
@@ -190,8 +190,17 @@ function M.confirm(message, opts, input)
       end
     end
 
-    local padding = math.floor((message:width() - message:last_line():width()) / 2)
-    table.insert(message:last_line()._texts, 1, NoiceText((" "):rep(padding)))
+    if opts.choices then
+      if opts.choices.align == "center" then
+        local padding = math.floor((message:width() - message:last_line():width()) / 2)
+        table.insert(message:last_line()._texts, 1, NoiceText((" "):rep(padding)))
+      elseif opts.choices.align == "right" then
+        local padding = math.floor((message:width() - message:last_line():width()))
+        table.insert(message:last_line()._texts, 1, NoiceText((" "):rep(padding)))
+      elseif opts.choices.align ~= "left" then
+        Util.panic("Invalid confirm formatter align value %s", opts.choices.align)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Currently `confirm`-kind events that are `confirm`-formatted have the choices line unconditionally padded to achieve center alignment.

Retain this behavior as the default, but allow users to left- and right-align as alternative options, e.g.:

```lua
{  
  opts = {
    views = {
      confirm = {
        format = {
          { "{confirm}", choices = { align = "left" } },
        },
      },
    },
  },
}
```

## Related Issue(s)

Closes https://github.com/folke/noice.nvim/issues/1089

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

```lua
format = {
  { "{confirm}", choices = { align = "left" } },
}
```

<img width="502" alt="image" src="https://github.com/user-attachments/assets/17ffc20b-d806-41cd-83db-4b69a31839ad" />

```lua
format = {
  { "{confirm}" },
}
```

<img width="516" alt="image" src="https://github.com/user-attachments/assets/b9c17268-a977-4b60-af7a-9274dbda44cf" />

```lua
format = {
  { "{confirm}", choices = { align = "right" } },
}
```

<img width="504" alt="image" src="https://github.com/user-attachments/assets/6cd3f5f4-77c9-4516-8fd6-a51dc6168b20" />
