### PR TITLE
fix(showMessage): use on_message handler

### DIFF
--- a/lua/noice/lsp/message.lua
+++ b/lua/noice/lsp/message.lua
@@ -17,7 +17,7 @@ M.message_type = {
 ---@alias ShowMessageParams {type:MessageType, message:string}
 
 function M.setup()
-  vim.lsp.handlers["window/showMessage"] = M._on_message
+  vim.lsp.handlers["window/showMessage"] = M.on_message
 end
 
 ---@param result ShowMessageParams


### PR DESCRIPTION
Replace typo _on_message with on_message in the LSP message handler.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Closes #1074 

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

