### PR TITLE
fix(hover): incorrect doc positions

### DIFF
--- a/lua/noice/util/nui.lua
+++ b/lua/noice/util/nui.lua
@@ -210,6 +210,8 @@ function M.anchorAndResizePopup(_opts)
   local has_border = (opts.border and opts.border.style and opts.border.style ~= "none")
   local border_offset = has_border and 2 or 0
 
+  local width = opts.size.width
+  ---@cast width number
   local height = opts.size.height
   ---@cast height number
 
@@ -224,7 +226,6 @@ function M.anchorAndResizePopup(_opts)
     -- first, adjust for the desired row offset (this will also handle borders)
     -- then adjust for padding (only worry about bottom padding when going down)
     opts.size.height = math.min(height, lines_below - row - padding.bottom)
-    vim.notify("h:" .. lines_below - padding.bottom - row)
   else
     anchor = anchor .. "S"
     -- when anchoring S, we invert the row position to draw "up" but
@@ -239,7 +240,7 @@ function M.anchorAndResizePopup(_opts)
     opts.size.height = math.min(height, lines_above - row - padding.top)
   end
 
-  if vim.go.columns - vim.fn.screencol() > opts.size.width then
+  if vim.go.columns - vim.fn.screencol() > width then
     anchor = anchor .. "W"
   else
     anchor = anchor .. "E"
@@ -248,10 +249,10 @@ function M.anchorAndResizePopup(_opts)
     -- we have to back out the border offset first since borders are
     -- drawn "inside" the col position
     -- then we apply any padding
-    vim.notify(vim.inspect(opts.position))
-    opts.position.col = -(col - border_offset) + 1 + opts.border.padding.left + opts.border.padding.right
-    vim.notify(vim.inspect(opts.position))
+    opts.position.col = -(col - border_offset) + 1 + padding.left + padding.right
   end
+
+  opts.size.width = math.min(width, vim.go.columns - padding.left - padding.right - border_offset)
 
   opts.anchor = anchor
 

--- a/lua/noice/view/nui.lua
+++ b/lua/noice/view/nui.lua
@@ -63,24 +63,7 @@ function NuiView:update_options()
   end
   if self._opts.anchor == "auto" then
     if self._opts.type == "popup" and self._opts.size then
-      local width = self._opts.size.width
-      local height = self._opts.size.height
-      if type(width) == "number" and type(height) == "number" then
-        local col = self._opts.position and self._opts.position.col
-        local row = self._opts.position and self._opts.position.row
-        local has_border = self._opts.border and self._opts.border.style ~= "none"
-        -- need to consider border when anchoring
-        self._opts.anchor = Util.nui.anchor(width, height + (has_border and 2 or 0))
-        if self._opts.anchor:find("S") and row then
-          -- if we're anchoring at the bottom, need to offset by border size
-          self._opts.position.row = -row + 1 + (has_border and 2 or 0)
-        end
-        if self._opts.anchor:find("E") and col then
-          self._opts.position.col = -col
-        end
-      end
-    else
-      self._opts.anchor = "NW"
+      self._opts = Util.nui.anchorAndResizePopup(self._opts --[[@as NuiPopupOptions]])
     end
   end
 end

--- a/lua/noice/view/nui.lua
+++ b/lua/noice/view/nui.lua
@@ -68,9 +68,12 @@ function NuiView:update_options()
       if type(width) == "number" and type(height) == "number" then
         local col = self._opts.position and self._opts.position.col
         local row = self._opts.position and self._opts.position.row
-        self._opts.anchor = Util.nui.anchor(width, height)
+        local has_border = self._opts.border and self._opts.border.style ~= "none"
+        -- need to consider border when anchoring
+        self._opts.anchor = Util.nui.anchor(width, height + (has_border and 2 or 0))
         if self._opts.anchor:find("S") and row then
-          self._opts.position.row = -row + 1
+          -- if we're anchoring at the bottom, need to offset by border size
+          self._opts.position.row = -row + 1 + (has_border and 2 or 0)
         end
         if self._opts.anchor:find("E") and col then
           self._opts.position.col = -col


### PR DESCRIPTION
## Description

The code to layout the lsp hover window was not handling a number of edge cases (anchoring E without a border, anchoring S and/or E with a border, and when hover window is too large to fit). These are all fixed and all combinations of position, padding, and border are handled correctly (afaik).

To fix all of these cases, we calculate position correctly, accounting for border and padding, and then set the maximum size accordingly.

Here are a bunch of screenshots to show the fixed layout:

No border:
1. below the cursor (anchoring NE)
<img width="1555" alt="Screenshot 2025-07-08 at 13 54 55" src="https://github.com/user-attachments/assets/9c03b43b-9b8e-4c9f-a26c-efb262a3a6fd" />
2. above the cursor (anchoring SE)
<img width="1546" alt="Screenshot 2025-07-08 at 13 55 04" src="https://github.com/user-attachments/assets/3b9c417c-57b3-476b-9e99-fce12f1dd424" />
3. anchoring NW
<img width="904" alt="Screenshot 2025-07-08 at 13 55 16" src="https://github.com/user-attachments/assets/b6dd8887-c872-426d-bad2-0770d2812493" />
4. anchoring SW
<img width="917" alt="Screenshot 2025-07-08 at 13 55 27" src="https://github.com/user-attachments/assets/7fec7b58-a5ce-4373-af87-a60d6c6d85f1" />

Border:
1. NE
<img width="1588" alt="Screenshot 2025-07-08 at 13 55 40" src="https://github.com/user-attachments/assets/b05407e1-25d7-41d3-88dd-c093e58001e3" />
2. SE
<img width="1669" alt="Screenshot 2025-07-08 at 13 55 56" src="https://github.com/user-attachments/assets/66e0632d-10ba-4075-b5fc-940b5f271bd5" />
3. NW
<img width="913" alt="Screenshot 2025-07-08 at 13 56 08" src="https://github.com/user-attachments/assets/72a444aa-511d-4467-82c4-3e95f0d97737" />
4.SW
<img width="841" alt="Screenshot 2025-07-08 at 14 06 17" src="https://github.com/user-attachments/assets/1c93c5f8-871b-4a90-9d29-88641a7e74f3" />

Overlapping other windows:
<img width="1619" alt="Screenshot 2025-07-08 at 13 56 35" src="https://github.com/user-attachments/assets/39cb20e0-65e3-4b3e-8555-0fe6bc5b6fd3" />

Resizing (so window doesn't get pushed onto cursor line, last line is statusline):
<img width="1553" alt="Screenshot 2025-07-08 at 14 18 30" src="https://github.com/user-attachments/assets/34e9b1c7-15bd-4592-acb0-a486b842a3b9" />

Resizing with small window:
<img width="1158" alt="Screenshot 2025-07-08 at 14 23 19" src="https://github.com/user-attachments/assets/ce7fe1bf-f84f-4ab7-83eb-5093cdb81791" />
<img width="1158" alt="Screenshot 2025-07-08 at 14 23 15" src="https://github.com/user-attachments/assets/2bd4a643-a056-49e9-99e3-1f41770c4647" />

Unusual position, padding with border and large max_height:

```lua
      lsp = {
        hover = {
          opts = {
            size = {
              max_height = 30,
            },
            position = { row = 5, col = 4 },
            border = {
              style = 'rounded',
              padding = { 2, 4 },
            },
          },
        },
      },

```
1. NE
<img width="1618" alt="Screenshot 2025-07-08 at 14 01 29" src="https://github.com/user-attachments/assets/5c0b8e29-c4a7-4992-8610-98408472d370" />
2. SE
<img width="1616" alt="Screenshot 2025-07-08 at 14 01 38" src="https://github.com/user-attachments/assets/f92843f9-16a8-4f54-8794-f482fab004cd" />
3. NW
<img width="1020" alt="Screenshot 2025-07-08 at 14 01 44" src="https://github.com/user-attachments/assets/22f16f54-ff83-43b6-aed4-7c42e82e7cbe" />
4. SW
<img width="922" alt="Screenshot 2025-07-08 at 14 01 56" src="https://github.com/user-attachments/assets/3448ae96-046a-4d19-858f-d2ca2c70caf9" />


## Related Issue(s)

Fixes #1122 

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

