### PR TITLE
Removing ANSI Control sequences from message output: PWSH 7

### DIFF
--- a/lua/noice/text/block.lua
+++ b/lua/noice/text/block.lua
@@ -167,10 +167,13 @@ function Block:append(contents, highlight)
       ---@type number|string|table, string
       local attr_id, text, hl_id = unpack(content)
       -- msg_show messages can contain invalid \r characters
+      -- and caret-notation ANSI control sequences
       if self.fix_cr ~= false then
         text = text:gsub("%^M", "\r")
         text = text:gsub("\r\n", "\n")
+        text = text:gsub("%^%[%[[%d;]*%a", "")
       end
+
 
       ---@type string|table|nil
       local hl_group


### PR DESCRIPTION
## Description

Noice assumes users on windows will be using the default cmd.exe shell.
As someone who does all windows scripting through powershell, I have set configured my neovim shell to be pwsh

```lua
vim.o.shell = "pwsh"
vim.o.shellcmdflag = "-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command"
vim.o.shellpipe = "| Out-File -Encoding UTF8 %s"
vim.o.shellquote = ""
vim.o.shellredir = "| Out-File -Encoding UTF8 %s"
vim.o.shellxquote = ""
```

When using Powershell 7, colors are pushed to the output with the default variable
``` powershell
$PSStyle.OutputRendering = 'Host'
```
which colors the terminal screen using ANSI control characters
|(ESC) | Param Start | (Position to color |   Param seperator) 1+ | Instruction(color is typically m)|
|:----:|:-----------:|:------------------:|:---------------------:|:--------------------------------:|
|^[    |  [          |   1-3 digits       |  ;                    |  1 alphabetical                  |

### Example:
**^[[30;1m **

When reading the terminal output, since these characters are being UTF8 encoded
through the shell piping, they are showing up in the notify message output.
It may be possible to turn the OutputRendering off, however, then there would
be no coloring whatsoever.

## Resolution
In the same place where CR and LF are removed, add an extra check for ANSI characters        
```lua
text = text:gsub("%^%[%[[%d;]*%a", "")
```


## Screenshots
### Working with CMD
![image](https://github.com/user-attachments/assets/d1ac64d8-f3d6-4ebd-b6fc-0d58d09c3be1)
### Same command with pwsh as neovim shell
![image](https://github.com/user-attachments/assets/5b930c09-67ab-4620-948f-4da96a4be01b)
### After filtering ANSI characters
![image](https://github.com/user-attachments/assets/d6594a8a-1b4c-4741-9296-70860eb3a902)

