### PR TITLE
fix: notification log level / urgency

### DIFF
--- a/lua/noice/view/backend/notify_send.lua
+++ b/lua/noice/view/backend/notify_send.lua
@@ -53,7 +53,7 @@ end
 ---@param level? NotifyLevel|number
 function NotifySendView:get_urgency(level)
   if level then
-    local l = type(level) == "number" and level or vim.log.levels[level:lower()] or vim.log.levels.INFO
+    local l = type(level) == "number" and level or vim.log.levels[level:upper()] or vim.log.levels.INFO
     if l <= 1 then
       return "low"
     end


### PR DESCRIPTION
## Description

The urgency was always set to normal because `vim.log.levels` uses uppercase keys rather than lowercase.

## Related Issue(s)

the urgency in `notify-send`

