### PR TITLE
fix(html): rendering of nbsp characters

### DIFF
--- a/lua/noice/text/markdown.lua
+++ b/lua/noice/text/markdown.lua
@@ -26,7 +26,7 @@ end
 
 ---@param text string
 function M.html_entities(text)
-  local entities = { nbsp = "", lt = "<", gt = ">", amp = "&", quot = '"', apos = "'", ensp = " ", emsp = " " }
+  local entities = { nbsp = " ", lt = "<", gt = ">", amp = "&", quot = '"', apos = "'", ensp = " ", emsp = " " }
   for entity, char in pairs(entities) do
     text = text:gsub("&" .. entity .. ";", char)
   end


### PR DESCRIPTION
## Description

Change the rendering of nbsp characters from `""` to `" "`

## Related Issue(s)

 #1068 

## Screenshots

Hovering on some python class.
```python
class Foo:

    """The Foo class

    Attributes
    ----------
    bar : int
        A very nice attribute
    baz : str
        Another very nice attribute

    """
    bar: int
    baz: str
```

Before:
<img width="374" height="235" alt="image" src="https://github.com/user-attachments/assets/ee3e4299-2e6e-428c-bbd4-2b4f17c562d5" />

After:
<img width="374" height="235" alt="image" src="https://github.com/user-attachments/assets/39709ab2-838f-46d0-95fd-2cba1658b493" />


