### PR TITLE
fix(markdown): fix render lines count

### DIFF
--- a/lua/noice/text/markdown.lua
+++ b/lua/noice/text/markdown.lua
@@ -202,8 +202,8 @@ function M.format(message, text, opts)
         for _, t in ipairs(M.get_highlights(block.line)) do
           message:append(t)
         end
-        md_lines = md_lines + 1
       end
+      md_lines = md_lines + 1
     end
   end
   emit_md()


### PR DESCRIPTION
## Description

The hover window renders markdown incorrectly. In lua/noice/text/markdown.lua, the horizontal_line should be included in md_lines.

## Screenshots

in c file:
before
<img width="377" height="227" alt="image" src="https://github.com/user-attachments/assets/60ab2c48-9138-472c-a805-6e3ca4e383f7" />

after
<img width="383" height="224" alt="image" src="https://github.com/user-attachments/assets/1195e4a6-6899-42a8-b0e1-0e66bc44deb8" />

in lua file:
before
<img width="901" height="350" alt="image" src="https://github.com/user-attachments/assets/ffb500ae-8660-4119-a348-0ce045055d75" />

after
<img width="915" height="364" alt="image" src="https://github.com/user-attachments/assets/5acf3014-d2bb-4617-9894-9ee201f88eac" />

