### PR TITLE
Fix: in function M.get_source()

### DIFF
--- a/lua/noice/health.lua
+++ b/lua/noice/health.lua
@@ -236,6 +236,13 @@ Either disable the other plugin or set `config.%s.enabled = false` in your **Noi
 end
 
 function M.get_source(fn)
+  if type(fn) ~= "function" then
+    return {
+      line = 0,
+      source = "unknown",
+      plugin = "unknown",
+    }
+  end
   local info = debug.getinfo(fn, "S")
   local source = info.source:sub(2)
   ---@class FunSource


### PR DESCRIPTION
## Description

This PR fixes a runtime error in `noice/health.lua` where `debug.getinfo` was called on values that were not functions.  
Previously, when `check.handler` was `nil` or a non-function, the health check would fail with:

```lua
E5108: Lua: bad argument #1 to 'getinfo' (function or level expected)
```
The fix adds a type check to `M.get_source(fn)` to ensure that only functions are passed to `debug.getinfo`.  
If the value is not a function, it now safely returns a fallback `{plugin = "unknown", source = "unknown", line = 0}` instead of throwing an error.

This prevents health checks from crashing and allows `:checkhealth noice` to complete gracefully.

- Fixes runtime error when running `:checkhealth noice` if `vim.notify` or other handlers are overridden by another plugin.

### Before
Health check crashed:
```lua
E5108: Lua: .../noice.nvim/lua/noice/health.lua:239: bad argument #1 to 'getinfo' (function or level expected)
```
### After
CheckHealth successful and returns
```lua
==============================================================================
noice:                                                                      ✅

noice.nvim ~
- ✅ OK *Neovim* >= 0.9.0
- ✅ OK You're using a GUI that should work ok
- ✅ OK *vim.go.lazyredraw* is not enabled
- ✅ OK `nvim-notify` is installed
- ✅ OK {TreeSitter} `vim` parser is installed
- ✅ OK {TreeSitter} `regex` parser is installed
- ✅ OK {TreeSitter} `lua` parser is installed
- ✅ OK {TreeSitter} `bash` parser is installed
- ✅ OK {TreeSitter} `markdown` parser is installed
- ✅ OK {TreeSitter} `markdown_inline` parser is installed
- ✅ OK `vim.notify` is set to **Noice**
- ✅ OK `vim.lsp.buf.hover` is set to **Noice**
- ✅ OK `vim.lsp.buf.signature_help` is set to **Noice**
- ✅ OK `vim.lsp.util.convert_input_to_markdown_lines` is set to **Noice**
- ✅ OK `vim.lsp.util.stylize_markdown` is set to **Noice**
```