### PR TITLE
fix(ui): set scrollbar window border to none

### DIFF
--- a/lua/noice/view/scrollbar.lua
+++ b/lua/noice/view/scrollbar.lua
@@ -171,6 +171,7 @@ function Scrollbar:_open_win(opts)
       col = 0,
       style = "minimal",
       noautocmd = true,
+      border = "none",
     }),
   }
   vim.api.nvim_set_option_value("winhighlight", "Normal:" .. opts.normal, { win = ret.winnr })


### PR DESCRIPTION
## Description

Fixes double border on scrollbar

## Related Issue(s)

https://github.com/folke/noice.nvim/issues/1082#issuecomment-2830859235

## Screenshots

<img width="2224" height="748" alt="image" src="https://github.com/user-attachments/assets/fa286f1b-430d-45d7-beda-cd16801f6088" />

