### PR TITLE
fix(spinners): update blank circle icon to be more consistent in size…

### DIFF
--- a/lua/noice/util/spinners.lua
+++ b/lua/noice/util/spinners.lua
@@ -187,7 +187,7 @@ M.spinners = {
   circleHalves = { frames = { "◐", "◓", "◑", "◒" }, interval = 50 },
   circleQuarters = { frames = { "◴", "◷", "◶", "◵" }, interval = 120 },
   circleFull = {
-    frames = { "", "󰪞", "󰪟", "󰪠", "󰪢", "󰪣", "󰪤", "󰪥" },
+    frames = { "󰄰", "󰪞", "󰪟", "󰪠", "󰪢", "󰪣", "󰪤", "󰪥" },
     interval = 120,
   },
   clock = {


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

I noticed inconsistent frame sizes in the `circleFull` spinner: the first empty circle was slightly larger than the rest, which made it look a bit glitchy. I found the correct size for the empty circle and applied it.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

Before
![inconsistent](https://github.com/user-attachments/assets/4e3c89ba-2605-4eb3-9879-df163c0eecc0)

After
![consistent](https://github.com/user-attachments/assets/0398dd74-0f96-4252-8f49-7b860159e17e)

