### PR TITLE
fix(cmdline): blink.cmp cmdline completion

### DIFF
--- a/lua/noice/util/hacks.lua
+++ b/lua/noice/util/hacks.lua
@@ -137,16 +137,15 @@ end
 M.SPECIAL = "Þ"
 ---@deprecated
 function M.cmdline_force_redraw()
-  if vim.fn.has("nvim-0.11") == 1 then
-    -- no longer needed on nightly
-    return
-  end
   if not require("noice.util.ffi").cmdpreview then
     return
   end
 
   -- HACK: this will trigger redraw during substitute and cmdpreview
+  local cmdpos = vim.fn.getcmdpos()
+  local cmdline = vim.fn.getcmdline()
   vim.api.nvim_feedkeys(M.SPECIAL .. Util.BS, "n", true)
+  vim.fn.setcmdline(cmdline, cmdpos)
 end
 
 ---@type string?


### PR DESCRIPTION
## Description

blink.cmp commandline completion wasn't working properly, and this hack seems to fix it.

## Related Issue(s)

maybe closes https://github.com/folke/noice.nvim/issues/958