### PR TITLE
feat(lsp): support multiple lsp servers for hover

### DIFF
--- a/lua/noice/lsp/hover.lua
+++ b/lua/noice/lsp/hover.lua
@@ -7,18 +7,72 @@ local Util = require("noice.util")
 
 local M = {}
 
-function M.on_hover(_, result, ctx)
-  if not (result and result.contents) then
+---@type lsp.MultiHandler
+function M.on_hover(results, ctx)
+  local bufnr = assert(ctx.bufnr)
+  if vim.api.nvim_get_current_buf() ~= bufnr then
+    -- Ignore result since buffer changed. This happens for slow language servers.
+    return
+  end
+
+  -- Filter errors from results
+  local results1 = {} --- @type table<integer,lsp.Hover>
+
+  for client_id, resp in pairs(results) do
+    local err, result = resp.err, resp.result
+    if err then
+      vim.lsp.log.error(err.code, err.message)
+    elseif result and result.contents then
+      -- Make sure the response is not empty
+      -- Five response shapes:
+      -- - MarkupContent: { kind="markdown", value="doc" }
+      -- - MarkedString-string: "doc"
+      -- - MarkedString-pair: { language="c", value="doc" }
+      -- - MarkedString[]-string: { "doc1", ... }
+      -- - MarkedString[]-pair: { { language="c", value="doc1" }, ... }
+      if
+        (
+          type(result.contents) == "table"
+          and #(
+              vim.tbl_get(result.contents, "value") -- MarkupContent or MarkedString-pair
+              or vim.tbl_get(result.contents, 1, "value") -- MarkedString[]-pair
+              or result.contents[1] -- MarkedString[]-string
+              or ""
+            )
+            > 0
+        )
+        or (
+          type(result.contents) == "string" and #result.contents > 0 -- MarkedString-string
+        )
+      then
+        results1[client_id] = result
+      end
+    end
+  end
+
+  if vim.tbl_isempty(results1) then
     if Config.options.lsp.hover.silent ~= true then
       vim.notify("No information available")
     end
     return
   end
 
+  local contents = {} --- @type MarkupContents[]
+
+  -- local nresults = #vim.tbl_keys(results1)
+
+  for _client_id, result in pairs(results1) do
+    contents[#contents + 1] = result.contents
+    contents[#contents + 1] = "---"
+  end
+
+  -- Remove last linebreak ('---')
+  contents[#contents] = nil
+
   local message = Docs.get("hover")
 
   if not message:focus() then
-    Format.format(message, result.contents, { ft = vim.bo[ctx.bufnr].filetype })
+    Format.format(message, contents, { ft = vim.bo[ctx.bufnr].filetype })
     if message:is_empty() then
       if Config.options.lsp.hover.silent ~= true then
         vim.notify("No information available")

--- a/lua/noice/lsp/init.lua
+++ b/lua/noice/lsp/init.lua
@@ -63,7 +63,7 @@ end
 
 function M.hover()
   local params = make_position_params()
-  vim.lsp.buf_request(0, "textDocument/hover", params, require("noice.lsp.hover").on_hover)
+  vim.lsp.buf_request_all(0, "textDocument/hover", params, require("noice.lsp.hover").on_hover)
 end
 
 function M.signature()


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Previously, during a hover operation, noice.nvim would only display the hover data returned by a single LSP, where a slower response would overwrite a faster one. Meanwhile, Neovim's built-in LSP handling for hover already merges and displays the hover responses from all LSPs. This PR incorporates Neovim's internal logic for merging hovers, enabling noice.nvim to simultaneously display hover information returned by multiple LSPs.

## Related Issue(s)

https://github.com/neovim/neovim/issues/36729

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<img width="1451" height="511" alt="image" src="https://github.com/user-attachments/assets/916c1c4a-3987-4f6d-8846-8711336b6ab2" />

<!-- Add screenshots of the changes if applicable. -->

