### PR TITLE
feat(message): add `clear_history`

### DIFF
--- a/lua/noice/message/manager.lua
+++ b/lua/noice/message/manager.lua
@@ -55,6 +55,18 @@ function M.clear(filter)
   end, filter)
 end
 
+---@param filter? NoiceFilter
+function M.clear_history(filter)
+  if not filter then
+    M._history = {}
+    return
+  end
+  M.with(function(message)
+    M._history[message.id] = nil
+    next_tick()
+  end, filter, { history = true })
+end
+
 ---@param max number
 function M.prune(max)
   local keep = M.get(nil, { count = max })


### PR DESCRIPTION
## Description

Allows to clear the message history. Useful when the history gets too large (can be slow depending on the machine).

## Related Issue(s)

[#731](https://github.com/folke/noice.nvim/issues/731)

## Questioning

Should we set the tick back to 1 when clearing the whole history?
