### PR TITLE
fix(preset): prevent confirm dialog from overlapping from cmdline_popup

### DIFF
--- a/lua/noice/config/preset.lua
+++ b/lua/noice/config/preset.lua
@@ -94,6 +94,11 @@ M.presets = {
           winhighlight = { Normal = "Normal", FloatBorder = "NoiceCmdlinePopupBorder" },
         },
       },
+      confirm = {
+        position = {
+          row = 6,
+        },
+      },
     },
   },
   long_message_to_split = {


### PR DESCRIPTION
## Description
Prevent confirm dialog from overlapping on ```cmdline_popup``` when enabling ```command_palette``` preset.

## Screenshots

Before
<img width="1103" height="243" alt="Screenshot 2026-01-28 102255" src="https://github.com/user-attachments/assets/8c4aa43c-e59c-4228-8de9-e89d92c7d3bc" />

After
<img width="1227" height="354" alt="Screenshot 2026-01-28 110525" src="https://github.com/user-attachments/assets/ce74dd1d-5cc2-4e0e-8812-9c0126c9c00b" />


