### PR TITLE
feat(markdown): render headings

### DIFF
--- a/lua/noice/config/init.lua
+++ b/lua/noice/config/init.lua
@@ -184,6 +184,9 @@ function M.defaults()
         ["^%s*(See also:)"] = "@text.title",
         ["{%S-}"] = "@parameter",
       },
+      icons = {
+        heading = "󰫎 ",
+      },
     },
     health = {
       checker = true, -- Disable if you don't want health checks to run

--- a/lua/noice/text/markdown.lua
+++ b/lua/noice/text/markdown.lua
@@ -265,10 +265,8 @@ end
 ---@param line string
 function M.heading(message, line)
   local level, title = line:match("^(#*)%s+(.*)$")
-  message:append(NoiceText("", {
-    virt_text_win_col = 0,
-    virt_text = { { Config.options.markdown.icons.heading .. title, "MarkdownH" .. #level } },
-    priority = 100,
+  message:append(NoiceText(Config.options.markdown.icons.heading .. title, {
+    hl_group = "MarkdownH" .. #level,
   }))
 end
 

--- a/lua/noice/text/markdown.lua
+++ b/lua/noice/text/markdown.lua
@@ -13,6 +13,10 @@ function M.is_rule(line)
   return line and line:find("^%s*[%*%-_][%*%-_][%*%-_]+%s*$")
 end
 
+function M.is_heading(line)
+  return line and line:find("^#*%s+")
+end
+
 function M.is_code_block(line)
   return line and line:find("^%s*```")
 end
@@ -197,6 +201,8 @@ function M.format(message, text, opts)
       message:newline()
       if M.is_rule(block.line) then
         M.horizontal_line(message)
+      elseif M.is_heading(block.line) then
+        M.heading(message, block.line)
       else
         message:append(block.line)
         for _, t in ipairs(M.get_highlights(block.line)) do
@@ -251,6 +257,17 @@ function M.horizontal_line(message)
   message:append(NoiceText("", {
     virt_text_win_col = 0,
     virt_text = { { string.rep("─", vim.go.columns), "@punctuation.special.markdown" } },
+    priority = 100,
+  }))
+end
+
+---@param message NoiceMessage
+---@param line string
+function M.heading(message, line)
+  local level, title = line:match("^(#*)%s+(.*)$")
+  message:append(NoiceText("", {
+    virt_text_win_col = 0,
+    virt_text = { { Config.options.markdown.icons.heading .. title, "MarkdownH" .. #level } },
     priority = 100,
   }))
 end

--- a/lua/noice/text/markdown.lua
+++ b/lua/noice/text/markdown.lua
@@ -14,7 +14,7 @@ function M.is_rule(line)
 end
 
 function M.is_heading(line)
-  return line and line:find("^#*%s+")
+  return line and line:find("^#+%s+")
 end
 
 function M.is_code_block(line)


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Adds highlighting of markdown headers in `noice/text/markdown.lua`, which can be useful for instance for lsp documentation.

## Related Issue(s)

None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
<img width="2072" height="1147" alt="image" src="https://github.com/user-attachments/assets/aeba0517-5214-43b4-865d-6bed1a9190be" />

