### PR TITLE
fix(ui): support transparency for multigrid UI

### DIFF
--- a/lua/noice/util/nui.lua
+++ b/lua/noice/util/nui.lua
@@ -6,15 +6,25 @@ local _ = require("nui.utils")._
 local M = {}
 
 M.transparent = false
+M.multigrid_ui = false
 
-local function check_bg()
+local function check_bg_ui()
   local normal = vim.api.nvim_get_hl(0, { name = "Normal" })
   M.transparent = not (normal and normal.bg ~= nil)
+
+  for _, ui in ipairs(vim.api.nvim_list_uis()) do
+    if ui.ext_multigrid then
+      M.multigrid_ui = true
+      return
+    end
+  end
 end
-check_bg()
+
+check_bg_ui()
+
 vim.api.nvim_create_autocmd("ColorScheme", {
   group = vim.api.nvim_create_augroup("noice_transparent", { clear = true }),
-  callback = check_bg,
+  callback = check_bg_ui,
 })
 
 ---@param opts? NoiceNuiOptions
@@ -40,7 +50,7 @@ function M.normalize_win_options(opts)
   if opts.win_options and opts.win_options.winhighlight then
     opts.win_options.winhighlight = Util.nui.get_win_highlight(opts.win_options.winhighlight)
   end
-  if opts.win_options and opts.win_options.winblend and M.transparent then
+  if opts.win_options and opts.win_options.winblend and M.transparent and not M.multigrid_ui then
     opts.win_options.winblend = 0
   end
 end


### PR DESCRIPTION
## Description

First all of thank you for such amazing plugin.

This PR is fix the `winblend` option for multigrid UI which is useful for Neovide.

When the Neovide is start without `--no-multigrid` flags, the `winblend` option value should use the value set by the user, not default to 0.

## Screenshots

### Config

```lua
require("noice").setup({
    views = {
        cmdline_popup = {
            win_options = {
                winblend = 100,
            },
        },
    },
})
```

### Before

<img width="600" height="112" alt="image" src="https://github.com/user-attachments/assets/cdeb5c5c-6d82-46ed-9806-fc61a8aa48d6" />

### After

<img width="639" height="116" alt="Screenshot 2026-05-05 at 13 15 53" src="https://github.com/user-attachments/assets/7b7ec5eb-a74e-494c-b3e5-7a0ad2d72d2c" />

Any feedback is appreciated.

