### PR TITLE
fix(lsp): attach showMessage handler

### DIFF
--- a/lua/noice/lsp/message.lua
+++ b/lua/noice/lsp/message.lua
@@ -17,7 +17,7 @@ M.message_type = {
 ---@alias ShowMessageParams {type:MessageType, message:string}
 
 function M.setup()
-  vim.lsp.handlers["window/showMessage"] = M._on_message
+  vim.lsp.handlers["window/showMessage"] = M.on_message
 end
 
 ---@param result ShowMessageParams

--- a/tests/lsp/message_spec.lua
+++ b/tests/lsp/message_spec.lua
@@ -1,0 +1,13 @@
+local Message = require("noice.lsp.message")
+
+describe("lsp messages", function()
+  it("installs the window/showMessage handler", function()
+    local original = vim.lsp.handlers["window/showMessage"]
+
+    Message.setup()
+
+    assert.equal(Message.on_message, vim.lsp.handlers["window/showMessage"])
+
+    vim.lsp.handlers["window/showMessage"] = original
+  end)
+end)


### PR DESCRIPTION
## Summary
- attach the LSP window/showMessage handler to noice.lsp.message.on_message instead of the nonexistent _on_message field
- add a regression test for handler setup

## Testing
- stylua --check lua/noice/lsp/message.lua tests/lsp/message_spec.lua
- scripts/test tests/lsp/message_spec.lua

Fixes #1074