### PR TITLE
fix(lsp): remove signature auto focus

### DIFF
--- a/lua/noice/lsp/signature.lua
+++ b/lua/noice/lsp/signature.lua
@@ -93,7 +93,7 @@ function M.on_signature(_, result, ctx, config)
 
   local message = Docs.get("signature")
 
-  if config.trigger or not message:focus() then
+  if config.trigger or not message:win() then
     result.ft = vim.bo[ctx.bufnr].filetype
     result.message = message
     M.new(result):format()


### PR DESCRIPTION
## Description

Change the default signature create action to solve the focus steal issue by replace `focus()` with `win()`.
`focus()`: check if the window exist, if true, set foucs into it.
`win()`: only return the window id, (for window checking here).
The old code uses `message:focus()` for both window detection and focus management (same as the hover window). If there don't have a window, we open a new one. And if there is already a window, we focus into it.
It makes sense for hover window, because it usually be toggled manually. But the signature mostly be triggerd automaticlly by the lsp. Under fast editing or navigating, the `check` might be called frequently and cause unexpected focus loss.

## About `focusable` not working
> A non-focusable window will be skipped by such commands as it isn't assigned a window number. It can be explicitly focused by nvim_set_current_win(), because it is still assigned a window-ID.
See [nvim api reference](https://neovim.io/doc/user/windows/#focusable)

Inside of `focus` uses `nvim_set_current_win()` to switch foucs. That's why it's useless just setting the window `focus=false`.
The lsp signature now will no longer mass up your focus. But I keep the `K`+`K` focus in for the hover window. If you use some kind of autocmd for hover, and don't want auto focus. You should check if the window already exists in your script like `if require("noice.lsp.docs").get("hover"):win()`.

## Stable Reproduction
- eg.1: `func` + `(` +`(`
You prees `(`, and signature window appears. After that, because the nvim.lsp.signature `setup()` attached `TextChangedI` with `check()`. So after you typing another `(`, there will trigger another `check()`, recognize the bracket and try to open the signature window again, steals focus from the editor area.
- eg.2: `func((` + backspace
Same reason as the above case.

## Related Issue(s)

Fixes #1172 #1016 #1101
Related #1206 #1017 #698

I also considerd to make the focus optional, but it needs extra config and code refactor. I finally choose to make the commit simple.
For those who still want to focus to the signature window manually, you can bind a key like:
```
vim.keymap.set("i", "<C-0>", function()
  require("noice.lsp.signature").check()
  require("noice.lsp.docs").get("signature"):focus()
end)
```