### PR TITLE
fix(popupmenu): flip popup above cursor when near bottom of window

### DIFF
--- a/lua/noice/ui/popupmenu/nui.lua
+++ b/lua/noice/ui/popupmenu/nui.lua
@@ -114,7 +114,8 @@ function M.opts(state)
     local offset = (border == nil or border == "none") and 0 or 1
     local lines_above = vim.fn.screenrow() - 1
     local lines_below = vim.fn.winheight(0) - lines_above
-    local popup_height = #state.items + offset * 2
+    local configured_height = opts.size and type(opts.size.height) == "number" and opts.size.height
+    local popup_height = (configured_height or #state.items) + offset * 2
     if popup_height < lines_below then
       opts.position = {
         row = 1 + offset,

--- a/lua/noice/ui/popupmenu/nui.lua
+++ b/lua/noice/ui/popupmenu/nui.lua
@@ -112,10 +112,21 @@ function M.opts(state)
     opts.relative = { type = "cursor" }
     local border = vim.tbl_get(opts, "border", "style")
     local offset = (border == nil or border == "none") and 0 or 1
-    opts.position = {
-      row = 1 + offset,
-      col = -padding.left,
-    }
+    local lines_above = vim.fn.screenrow() - 1
+    local lines_below = vim.fn.winheight(0) - lines_above
+    local popup_height = #state.items + offset * 2
+    if popup_height < lines_below then
+      opts.position = {
+        row = 1 + offset,
+        col = -padding.left,
+      }
+    else
+      opts.anchor = "SW"
+      opts.position = {
+        row = 0,
+        col = -padding.left,
+      }
+    end
   end
 
   -- manage left/right padding on the line


### PR DESCRIPTION
## Description

When the cursor is near the bottom of the buffer, the completion pop-up is always placed below the cursor line, causing it to overlap or go off-screen. Now it checks the available lines below and uses anchor SW to flip the popup above the cursor when needed

## Screenshots
### Before
<img width="877" height="805" alt="before" src="https://github.com/user-attachments/assets/b9fba426-2d1a-44de-bf05-1693815f11ec" />

### After
<img width="877" height="805" alt="after" src="https://github.com/user-attachments/assets/f3edffd6-eb62-43d0-a605-79c290fa7a11" />