### PR TITLE
fix(ui): handle confirm message as a single line with buttons

### DIFF
--- a/lua/noice/ui/cmdline.lua
+++ b/lua/noice/ui/cmdline.lua
@@ -190,6 +190,9 @@ function M.on_show(event, content, pos, firstc, prompt, indent, level)
 
   if M.confirm_message then
     local message = M.confirm_message --[[@as NoiceMessage]]
+    if message:is_empty() or message:last_line():content() ~= "" then
+      message:newline()
+    end
     message:append(prompt)
     M.confirm_message = nil
     Manager.add(message)

--- a/tests/ui/cmdline_spec.lua
+++ b/tests/ui/cmdline_spec.lua
@@ -1,0 +1,49 @@
+local Cmdline = require("noice.ui.cmdline")
+local Manager = require("noice.message.manager")
+local Message = require("noice.message")
+
+describe("cmdline confirm", function()
+  local handle_confirm
+
+  before_each(function()
+    handle_confirm = Cmdline.handle_confirm
+    Cmdline.handle_confirm = true
+    Cmdline.confirm_message = nil
+    Cmdline._on_hide = nil
+  end)
+
+  after_each(function()
+    Cmdline.handle_confirm = handle_confirm
+    Cmdline.confirm_message = nil
+    Cmdline._on_hide = nil
+  end)
+
+  it("separates the confirm message from the cmdline prompt", function()
+    local message = Message("msg_show", "confirm", "Save changes? ")
+
+    assert.is_true(Cmdline.on_confirm(message))
+    Cmdline.on_show("cmdline_show", {}, 0, "", " &Yes\n&No", 0, 1)
+
+    assert.equal("Save changes? \n &Yes\n&No", message:content())
+    assert.is_true(Manager.has(message, { history = true }))
+  end)
+
+  it("does not add an extra separator when the confirm message already ends with an empty line", function()
+    local message = Message("msg_show", "confirm", "Save changes? \n")
+
+    assert.is_true(Cmdline.on_confirm(message))
+    Cmdline.on_show("cmdline_show", {}, 0, "", " &Yes\n&No", 0, 1)
+
+    assert.equal("Save changes? \n &Yes\n&No", message:content())
+  end)
+
+  it("does not handle confirm messages on Neovim versions without cmdline confirm prompts", function()
+    Cmdline.handle_confirm = false
+
+    local message = Message("msg_show", "confirm", "Save changes? ")
+
+    assert.is_false(Cmdline.on_confirm(message))
+    assert.equal("Save changes? ", message:content())
+    assert.is_nil(Cmdline.confirm_message)
+  end)
+end)


### PR DESCRIPTION
## Description

From neovim 0.12 the confirm message comes as a single line with both the question and the buttons. This pull request adds a newline between the message and the buttons to fix the UI.

## Related Issue(s)

Fixes #1198

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #1198
-->

## Screenshots

Before:
<img width="1760" height="136" alt="image" src="https://github.com/user-attachments/assets/acf69aed-4f4b-4a6d-be71-a56eff728708" />

After:
<img width="1344" height="246" alt="image" src="https://github.com/user-attachments/assets/1de39170-f4ef-4c3a-958c-6c610b098dbd" />