### PR TITLE
fix(docs): replace deprecated nerdfont help icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Check the [wiki](https://github.com/folke/noice.nvim/wiki/Configuration-Recipes)
       search_up = { kind = "search", pattern = "^%?", icon = " ", lang = "regex" },
       filter = { pattern = "^:%s*!", icon = "$", lang = "bash" },
       lua = { pattern = { "^:%s*lua%s+", "^:%s*lua%s*=%s*", "^:%s*=%s*" }, icon = "", lang = "lua" },
-      help = { pattern = "^:%s*he?l?p?%s+", icon = "" },
+      help = { pattern = "^:%s*he?l?p?%s+", icon = "󰋖" },
       input = { view = "cmdline_input", icon = "󰥻 " }, -- Used by input()
       -- lua = false, -- to disable a format, set to `false`
     },

--- a/doc/noice.nvim.txt
+++ b/doc/noice.nvim.txt
@@ -150,7 +150,7 @@ for configuration recipes.
           search_up = { kind = "search", pattern = "^%?", icon = " ", lang = "regex" },
           filter = { pattern = "^:%s*!", icon = "$", lang = "bash" },
           lua = { pattern = { "^:%s*lua%s+", "^:%s*lua%s*=%s*", "^:%s*=%s*" }, icon = "", lang = "lua" },
-          help = { pattern = "^:%s*he?l?p?%s+", icon = "" },
+          help = { pattern = "^:%s*he?l?p?%s+", icon = "󰋖" },
           input = { view = "cmdline_input", icon = "󰥻 " }, -- Used by input()
           -- lua = false, -- to disable a format, set to `false`
         },


### PR DESCRIPTION
## Description

Nerdfonts v3.0.0 Release (2023.04.30):
- Dropped codepoints F500… and class names nf-mdi-*
- New codepoints F0001… and class names nf-md-*