### PR TITLE
fix(api): replace deprecated option setters

### DIFF
--- a/lua/noice/util/init.lua
+++ b/lua/noice/util/init.lua
@@ -279,10 +279,10 @@ function M.notify(msg, level, ...)
     require("notify").notify(msg:format(...), level, {
       title = "noice.nvim",
       on_open = function(win)
-        vim.api.nvim_win_set_option(win, "conceallevel", 3)
+        M.wo(win, { conceallevel = 3 })
         local buf = vim.api.nvim_win_get_buf(win)
-        vim.api.nvim_buf_set_option(buf, "filetype", "markdown")
-        vim.api.nvim_win_set_option(win, "spell", false)
+        vim.api.nvim_set_option_value("filetype", "markdown", { scope = "local", buf = buf })
+        vim.api.nvim_set_option_value("spell", false, { scope = "local", win = win })
       end,
     })
   else

--- a/lua/telescope/_extensions/noice.lua
+++ b/lua/telescope/_extensions/noice.lua
@@ -56,7 +56,7 @@ function M.previewer()
   return previewers.new_buffer_previewer({
     title = "Message",
     define_preview = function(self, entry, _status)
-      vim.api.nvim_win_set_option(self.state.winid, "wrap", true)
+      vim.api.nvim_set_option_value("wrap", true, { scope = "local", win = self.state.winid })
 
       ---@type NoiceMessage
       local message = Format.format(entry.message, "telescope_preview")
@@ -97,8 +97,8 @@ function M.mappings()
         border = "rounded",
       })
 
-      vim.api.nvim_win_set_option(win, "wrap", true)
-      vim.api.nvim_buf_set_option(buf, "modifiable", false)
+      vim.api.nvim_set_option_value("wrap", true, { scope = "local", win = win })
+      vim.api.nvim_set_option_value("modifiable", false, { scope = "local", buf = buf })
     end)
 
     return true


### PR DESCRIPTION
## Description

Replace six [deprecated buffer- and window-specific option setters](https://neovim.io/doc/user/deprecated/#deprecated-0.10) in the
notification and Telescope paths.

The scoped replacements preserve each local buffer or window target.

Tested with:

- `stylua --check lua/noice/util/init.lua lua/telescope/_extensions/noice.lua`
- Headless buffer/window option-target probe

## Related Issue(s)

None.

## Screenshots

Not applicable.